### PR TITLE
Uses `XDG_CACHE_HOME` for `since` cache.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -Wno-typed-holes #-}
 module Main where
 
 import CofreeBot
@@ -8,31 +7,37 @@ import Data.Text qualified as T
 import Network.Matrix.Client
 import Options.Applicative qualified as Opt
 import OptionsParser
-
+import System.Environment ( getEnv, lookupEnv )
 {-
 *This is a very scrappy rough draft*
 
 TODO:
 - [ ] Handle Full RoomEvents
-- [ ] Use XDG Directories
 - [ ] Automated Build and Deploy to server
 - [ ] Test suite
 - [ ] Administrative interface (via private message?)
 - [ ] Command to list all sessions
 - [ ] Add fixed point of Bot
+- [ ] Bot should auto join DMs
 -}
+
+findXdgCache :: IO String
+findXdgCache = do
+  home <- getEnv "HOME"
+  fmap (maybe (home <> "/.cache/cofree-bot") (<> "/cofree-bot")) $ lookupEnv "XDG_CACHE_HOME"
 
 main :: IO ()
 main = do
   --runSimpleBot (simplifySessionBot (T.intercalate "\n" . printCalcOutput) programP $ sessionize mempty $ calculatorBot) mempty
   command <- Opt.execParser parserInfo
+  xdg_cache <- findXdgCache
   let calcBot = liftSimpleBot $ simplifySessionBot (T.intercalate "\n" . printCalcOutput) programP $ sessionize mempty $ calculatorBot
       helloBot = helloMatrixBot
       bot = rmap (uncurry (<>)) $ calcBot /\ helloBot
   case command of
     LoginCmd cred -> do
       session <- login cred
-      runMatrixBot session bot mempty
+      runMatrixBot session xdg_cache bot mempty
     TokenCmd TokenCredentials{..} -> do
       session <- createSession (getMatrixServer matrixServer) matrixToken
-      runMatrixBot session bot mempty
+      runMatrixBot session xdg_cache bot mempty

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,6 +8,7 @@ import Network.Matrix.Client
 import Options.Applicative qualified as Opt
 import OptionsParser
 import System.Environment ( getEnv, lookupEnv )
+import System.Environment.XDG.BaseDir ( getUserCacheDir )
 {-
 *This is a very scrappy rough draft*
 
@@ -30,14 +31,14 @@ main :: IO ()
 main = do
   --runSimpleBot (simplifySessionBot (T.intercalate "\n" . printCalcOutput) programP $ sessionize mempty $ calculatorBot) mempty
   command <- Opt.execParser parserInfo
-  xdg_cache <- findXdgCache
+  xdgCache <- getUserCacheDir "cofree-bot"
   let calcBot = liftSimpleBot $ simplifySessionBot (T.intercalate "\n" . printCalcOutput) programP $ sessionize mempty $ calculatorBot
       helloBot = helloMatrixBot
       bot = rmap (uncurry (<>)) $ calcBot /\ helloBot
   case command of
     LoginCmd cred -> do
       session <- login cred
-      runMatrixBot session xdg_cache bot mempty
+      runMatrixBot session xdgCache bot mempty
     TokenCmd TokenCredentials{..} -> do
       session <- createSession (getMatrixServer matrixServer) matrixToken
-      runMatrixBot session xdg_cache bot mempty
+      runMatrixBot session xdgCache bot mempty

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,7 +7,6 @@ import Data.Text qualified as T
 import Network.Matrix.Client
 import Options.Applicative qualified as Opt
 import OptionsParser
-import System.Environment ( getEnv, lookupEnv )
 import System.Environment.XDG.BaseDir ( getUserCacheDir )
 {-
 *This is a very scrappy rough draft*
@@ -21,11 +20,6 @@ TODO:
 - [ ] Add fixed point of Bot
 - [ ] Bot should auto join DMs
 -}
-
-findXdgCache :: IO String
-findXdgCache = do
-  home <- getEnv "HOME"
-  fmap (maybe (home <> "/.cache/cofree-bot") (<> "/cofree-bot")) $ lookupEnv "XDG_CACHE_HOME"
 
 main :: IO ()
 main = do

--- a/cofree-bot.cabal
+++ b/cofree-bot.cabal
@@ -58,6 +58,7 @@ executable cofree-bot
   build-depends:
       cofree-bot
     , optparse-applicative
+    , xdg-basedir
   other-modules:
     OptionsParser
 

--- a/src/CofreeBot/Bot/Matrix.hs
+++ b/src/CofreeBot/Bot/Matrix.hs
@@ -25,10 +25,10 @@ readFileMaybe path =
       then pure Nothing
       else throwIO e
 
-runMatrixBot :: forall s. ClientSession -> MatrixBot IO s -> s -> IO ()
-runMatrixBot session bot s = do
+runMatrixBot :: forall s. ClientSession -> String -> MatrixBot IO s -> s -> IO ()
+runMatrixBot session cache bot s = do
   ref <- newIORef s
-  since <- readFileMaybe "/tmp/cofree-bot-since_file"
+  since <- readFileMaybe $ cache <> "/since_file"
   void $ runExceptT $ do
     userId <- ExceptT $ getTokenOwner session
     filterId <- ExceptT $ createFilter session userId messageFilter
@@ -45,7 +45,7 @@ runMatrixBot session bot s = do
            events :: [(RoomID, Event)]
            events = Map.foldMapWithKey (\rid es -> fmap ((RoomID rid,) . view _reContent) es) roomEvents
 
-       liftIO $ writeFile "/tmp/cofree-bot-since_file" (T.unpack newSince)
+       liftIO $ writeFile (cache <> "/since_file") (T.unpack newSince)
        pPrint roomEvents
        traverse_ (go ref) events
   where


### PR DESCRIPTION
Moves `since` cache from `/tmp` to `XDG_CACHE_HOME`.