### PR TITLE
Adds docker image nix derivation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,10 @@
-name: "Nix Build Docker Image"
+name: "Nix Build and Deploy Docker Image"
 on:
-  pull_request:
   push:
+    branches:
+      - main
 jobs:
-  tests:
+  docker:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
@@ -11,4 +12,4 @@ jobs:
       with:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - run: nix build .#docker
+    - run: ./deploy.sh

--- a/cofree-bot.cabal
+++ b/cofree-bot.cabal
@@ -83,6 +83,7 @@ library
     , aeson
     , attoparsec
     , containers
+    , directory
     , hint
     , lens
     , mtl

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+nix build .#docker
+image=$(docker load -i result | sed -n 's#^Loaded image: \([a-zA-Z0-9\.\/\-\:]*\)#\1#p')
+docker push $image

--- a/docker.nix
+++ b/docker.nix
@@ -3,8 +3,9 @@ let
   overlay = import ./overlay.nix { inherit compiler; };
   pkgs = import <nixpkgs> { overlays = [overlay]; };
 in
-  { myAppImage = pkgs.dockerTools.buildImage {
+  { myAppImage = pkgs.dockerTools.buildLayeredImage {
       name = "cofree.coffee/cofree-bot";
+      created = "now";
       contents = [ 
         pkgs.haskellPackages.cofree-bot
         pkgs.bash

--- a/docker.nix
+++ b/docker.nix
@@ -1,20 +1,19 @@
+{ pkgs }:
 let
   compiler = "ghc8107";
   overlay = import ./overlay.nix { inherit compiler; };
-  pkgs = import <nixpkgs> { overlays = [overlay]; };
 in
-  { myAppImage = pkgs.dockerTools.buildLayeredImage {
-      name = "cofree.coffee/cofree-bot";
+  pkgs.dockerTools.buildLayeredImage {
+      name = "ghcr.io/cofree-coffee/cofree-bot";
       created = "now";
       contents = [ 
         pkgs.bash
-        pkgs.coreutils
         pkgs.cacert
       ];
       config = {
+        Entrypoint = "${pkgs.bash}/bin/bash";
         Cmd = [ 
-          "${pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.cofree-bot}/bin/cofree-bot" "run" "--auth_token" "xyz" "--homeserver" "https://matrix.cofree.coffee"
+          "-c" "${pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.cofree-bot}/bin/cofree-bot run --auth_token $AUTH_TOKEN --homeserver https://matrix.cofree.coffee"
         ];
       };
-    };
-  }
+    }

--- a/docker.nix
+++ b/docker.nix
@@ -7,14 +7,13 @@ in
       name = "cofree.coffee/cofree-bot";
       created = "now";
       contents = [ 
-        pkgs.haskellPackages.cofree-bot
         pkgs.bash
         pkgs.coreutils
         pkgs.cacert
       ];
       config = {
         Cmd = [ 
-          "${pkgs.haskellPackages.cofree-bot}/bin/cofree-bot" "run" "--auth_token" "xyz" "--homeserver" "https://matrix.cofree.coffee"
+          "${pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.cofree-bot}/bin/cofree-bot" "run" "--auth_token" "xyz" "--homeserver" "https://matrix.cofree.coffee"
         ];
       };
     };

--- a/docker.nix
+++ b/docker.nix
@@ -1,0 +1,20 @@
+let
+  compiler = "ghc8107";
+  overlay = import ./overlay.nix { inherit compiler; };
+  pkgs = import <nixpkgs> { overlays = [overlay]; };
+in
+  { myAppImage = pkgs.dockerTools.buildImage {
+      name = "cofree.coffee/cofree-bot";
+      contents = [ 
+        pkgs.haskellPackages.cofree-bot
+        pkgs.bash
+        pkgs.coreutils
+        pkgs.cacert
+      ];
+      config = {
+        Cmd = [ 
+          "${pkgs.haskellPackages.cofree-bot}/bin/cofree-bot" "run" "--auth_token" "xyz" "--homeserver" "https://matrix.cofree.coffee"
+        ];
+      };
+    };
+  }

--- a/flake.nix
+++ b/flake.nix
@@ -35,5 +35,6 @@
           };
           defaultPackage =
             pkgs.haskellPackages.cofree-bot;
+          packages.docker = import ./docker.nix { inherit pkgs; };
         } // { inherit overlay overlays; });
 }

--- a/src/CofreeBot/Bot/Matrix.hs
+++ b/src/CofreeBot/Bot/Matrix.hs
@@ -10,7 +10,6 @@ import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Network.Matrix.Client
 import Network.Matrix.Client.Lens
-import Text.Pretty.Simple
 import Data.IORef
 import System.Directory ( createDirectoryIfMissing )
 import System.IO.Error ( isDoesNotExistError )
@@ -48,7 +47,7 @@ runMatrixBot session cache bot s = do
            events = Map.foldMapWithKey (\rid es -> fmap ((RoomID rid,) . view _reContent) es) roomEvents
 
        liftIO $ writeFile (cache <> "/since_file") (T.unpack newSince)
-       pPrint roomEvents
+       --print roomEvents
        traverse_ (go ref) events
   where
     go :: MonadIO m => IORef s -> (RoomID, Event) -> m ()

--- a/src/CofreeBot/Bot/Matrix.hs
+++ b/src/CofreeBot/Bot/Matrix.hs
@@ -12,8 +12,9 @@ import Network.Matrix.Client
 import Network.Matrix.Client.Lens
 import Text.Pretty.Simple
 import Data.IORef
-import System.Random ( newStdGen, randoms )
+import System.Directory ( createDirectoryIfMissing )
 import System.IO.Error ( isDoesNotExistError )
+import System.Random ( newStdGen, randoms )
 import Control.Exception ( catch, throwIO )
 
 type MatrixBot m s = Bot m s (RoomID, Event) [(RoomID, Event)]
@@ -28,6 +29,7 @@ readFileMaybe path =
 runMatrixBot :: forall s. ClientSession -> String -> MatrixBot IO s -> s -> IO ()
 runMatrixBot session cache bot s = do
   ref <- newIORef s
+  createDirectoryIfMissing True cache
   since <- readFileMaybe $ cache <> "/since_file"
   void $ runExceptT $ do
     userId <- ExceptT $ getTokenOwner session


### PR DESCRIPTION
Adds a derivation for constructing a docker image. It works as is but the image is 3gb and contains all our build dependencies. Would be great to remove this cruft.

```
➜ docker load < $(nix-build docker.nix)
these 5 derivations will be built:
  /nix/store/rlcnjvzvj6za45g2vx22akid5zsmany1-cofree-bot-0.1.0.0.drv
  /nix/store/k7cf5spcf66blg9l4swx0n4fpikzw3r5-cofree-bot-config.json.drv
  /nix/store/2ikia4zq9q3c09hdcr1ab5s9xgfznjlf-docker-layer-cofree-bot.drv
  /nix/store/2yqvwgdpx2igh0hxgwgf40mmr09kiv77-runtime-deps.drv
  /nix/store/ymssar3rcnaiys5dxahziznjhp5a3id1-docker-image-cofree-bot.tar.gz.drv
...
```

Also still need to sort out how to pass in auth tokens securely.