### PR TITLE
In-Memory Todo List Bot Behavior

### DIFF
--- a/chat-bots-contrib/chat-bots-contrib.cabal
+++ b/chat-bots-contrib/chat-bots-contrib.cabal
@@ -76,6 +76,7 @@ library
     Data.Chat.Bot.Hello
     Data.Chat.Bot.Jitsi
     Data.Chat.Bot.Jitsi.Dictionary
+    Data.Chat.Bot.Lists
     Data.Chat.Bot.Magic8Ball
     Data.Chat.Bot.Updog
     Data.Chat.Server.Matrix

--- a/chat-bots-contrib/src/Data/Chat/Bot/Lists.hs
+++ b/chat-bots-contrib/src/Data/Chat/Bot/Lists.hs
@@ -1,47 +1,71 @@
--- | A Bot Behavior for managing todo lists
+-- | A Bot Behavior for managing lists
 module Data.Chat.Bot.Lists
-  ( listBot,
-    TodoAction (..),
+  ( listsBot,
   )
 where
 
 --------------------------------------------------------------------------------
 
 import Control.Applicative
+import Data.Attoparsec.ByteString.Char8
+  ( isSpace,
+  )
 import Data.Attoparsec.Text
 import Data.Chat.Bot
 import Data.Chat.Bot.Monoidal
 import Data.Chat.Utils (indistinct)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.Profunctor
 import Data.Text qualified as T
 
 --------------------------------------------------------------------------------
 
-data TodoAction = Create T.Text | Modify Int T.Text | Remove Int | List
+data ListItemAction = Insert T.Text | Modify Int T.Text | Remove Int
 
-listBot' :: (Monad m) => Bot m (IntMap T.Text) TodoAction T.Text
-listBot' = Bot $ \s -> \case
-  Create todo ->
+data ListAction = CreateList T.Text | ModifyList T.Text ListItemAction | RemoveList T.Text | List T.Text
+
+listItemBot :: (Monad m) => Bot m (IntMap T.Text) ListItemAction T.Text
+listItemBot = Bot $ \s -> \case
+  Insert todo ->
     let k = freshKey s in pure ("Entry added", IntMap.insert k todo s)
   Modify k todo -> pure ("Entry updated", IntMap.insert k todo s)
   Remove k -> pure ("Entry deleted", IntMap.delete k s)
-  List -> pure (T.pack $ show s, s)
 
 freshKey :: IntMap a -> Int
 freshKey state = case IntMap.lookupMax state of
   Nothing -> 0
   Just (k, _) -> k + 1
 
-listBot :: (Monad m) => Bot m (s, (IntMap T.Text)) T.Text T.Text
-listBot = dimap (parseOnly parseAction) indistinct $ emptyBot \/ listBot'
+listsBot' :: (Monad m) => Bot m (Map T.Text (IntMap T.Text)) ListAction T.Text
+listsBot' = Bot $ \s -> \case
+  CreateList name -> pure ("List Created", Map.insert name mempty s)
+  ModifyList name action -> do
+    let t = fromMaybe IntMap.empty $ Map.lookup name s
+    t' <- fmap snd $ runBot listItemBot t action
+    pure ("List Updated", Map.insert name t' s)
+  RemoveList name -> pure ("List deleted", Map.delete name s)
+  List name -> pure (T.pack $ show $ Map.lookup name s, s)
 
-parseAction :: Parser TodoAction
-parseAction = parseAdd <|> parseRemove <|> parseModify <|> parseList
+listsBot :: (Monad m) => Bot m (s, (Map T.Text (IntMap T.Text))) T.Text T.Text
+listsBot = dimap (parseOnly parseListAction) indistinct $ emptyBot \/ listsBot'
+
+parseListAction :: Parser ListAction
+parseListAction =
+  parseCreateList <|> parseModifyList <|> parseRemoveList <|> parseListList
   where
-    parseAdd = "create-todo:" *> skipSpace *> fmap Create takeText
-    parseRemove = "remove-todo:" *> skipSpace *> fmap Remove decimal
-    parseModify =
-      "modify-todo:" *> skipSpace *> fmap (Modify) decimal <* space <*> takeText
-    parseList = "list-todos" *> pure List
+    parseCreateList = "create" *> skipSpace *> fmap CreateList (takeTill isSpace)
+    parseModifyList =
+      "add"
+        *> skipSpace
+        *> fmap ModifyList (takeTill isSpace)
+        <*> fmap Insert takeText
+    parseRemoveList =
+      "remove"
+        *> skipSpace
+        *> fmap ModifyList (takeTill isSpace)
+        <*> fmap Remove decimal
+    parseListList = "show" *> skipSpace *> fmap List takeText

--- a/chat-bots-contrib/src/Data/Chat/Bot/Lists.hs
+++ b/chat-bots-contrib/src/Data/Chat/Bot/Lists.hs
@@ -1,0 +1,47 @@
+-- | A Bot Behavior for managing todo lists
+module Data.Chat.Bot.Lists
+  ( listBot,
+    TodoAction (..),
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Control.Applicative
+import Data.Attoparsec.Text
+import Data.Chat.Bot
+import Data.Chat.Bot.Monoidal
+import Data.Chat.Utils (indistinct)
+import Data.IntMap.Strict (IntMap)
+import Data.IntMap.Strict qualified as IntMap
+import Data.Profunctor
+import Data.Text qualified as T
+
+--------------------------------------------------------------------------------
+
+data TodoAction = Create T.Text | Modify Int T.Text | Remove Int | List
+
+listBot' :: (Monad m) => Bot m (IntMap T.Text) TodoAction T.Text
+listBot' = Bot $ \s -> \case
+  Create todo ->
+    let k = freshKey s in pure ("Entry added", IntMap.insert k todo s)
+  Modify k todo -> pure ("Entry updated", IntMap.insert k todo s)
+  Remove k -> pure ("Entry deleted", IntMap.delete k s)
+  List -> pure (T.pack $ show s, s)
+
+freshKey :: IntMap a -> Int
+freshKey state = case IntMap.lookupMax state of
+  Nothing -> 0
+  Just (k, _) -> k + 1
+
+listBot :: (Monad m) => Bot m (s, (IntMap T.Text)) T.Text T.Text
+listBot = dimap (parseOnly parseAction) indistinct $ emptyBot \/ listBot'
+
+parseAction :: Parser TodoAction
+parseAction = parseAdd <|> parseRemove <|> parseModify <|> parseList
+  where
+    parseAdd = "create-todo:" *> skipSpace *> fmap Create takeText
+    parseRemove = "remove-todo:" *> skipSpace *> fmap Remove decimal
+    parseModify =
+      "modify-todo:" *> skipSpace *> fmap (Modify) decimal <* space <*> takeText
+    parseList = "list-todos" *> pure List

--- a/chat-bots-contrib/src/Data/Chat/Bot/Lists.hs
+++ b/chat-bots-contrib/src/Data/Chat/Bot/Lists.hs
@@ -49,7 +49,15 @@ listsBot' = Bot $ \s -> \case
     t' <- fmap snd $ runBot listItemBot t action
     pure ("List Updated", Map.insert name t' s)
   DeleteList name -> pure ("List deleted", Map.delete name s)
-  ShowList name -> pure (T.pack $ show $ Map.lookup name s, s)
+  ShowList name -> pure (prettyListM name $ Map.lookup name s, s)
+
+prettyList :: T.Text -> IntMap T.Text -> T.Text
+prettyList name list = name <> ":\n" <> foldr (\(i, x) acc -> T.pack (show i) <> ". " <> x <> "\n" <> acc) mempty (IntMap.toList list)
+
+prettyListM :: T.Text -> Maybe (IntMap T.Text) -> T.Text
+prettyListM name = \case
+  Nothing -> "List '" <> name <> "' not found."
+  Just l -> prettyList name l
 
 listsBot :: (Monad m) => Bot m (s, (Map T.Text (IntMap T.Text))) T.Text T.Text
 listsBot = dimap (parseOnly parseListAction) indistinct $ emptyBot \/ listsBot'

--- a/cofree-bot/app/Main.hs
+++ b/cofree-bot/app/Main.hs
@@ -19,6 +19,7 @@ import Data.Chat.Bot.GHCI
 import Data.Chat.Bot.HKD
 import Data.Chat.Bot.Hello
 import Data.Chat.Bot.Jitsi
+import Data.Chat.Bot.Lists qualified as Lists
 import Data.Chat.Bot.Magic8Ball
 import Data.Chat.Bot.Serialization qualified as S
 import Data.Chat.Bot.Updog
@@ -66,7 +67,8 @@ data CofreeBot p = CofreeBot
     magic8Ball :: p () () Int,
     jitsi :: p () () Text,
     ghci :: p () Text Text,
-    calclator :: p (SessionState CalcState) (SessionInput Statement) (SessionOutput (Either CalcError CalcResp))
+    calclator :: p (SessionState CalcState) (SessionInput Statement) (SessionOutput (Either CalcError CalcResp)),
+    lists :: p (Lists.ListsState) Lists.ListAction Text
   }
   deriving stock (Generic)
   deriving anyclass (SequenceBot, SequenceSer)
@@ -89,6 +91,7 @@ bot' process =
     jitsiBot
     (ghciBot process)
     (sessionize mempty calculatorBot)
+    Lists.listsBot
 
 serializer' :: CofreeBot Contorted
 serializer' =
@@ -100,6 +103,7 @@ serializer' =
     (Contort jitsiSerializer)
     (Contort ghciSerializer)
     (Contort $ sessionSerializer calculatorSerializer)
+    (Contort $ Lists.listsBotSerializer)
 
 bot :: Process Handle Handle () -> Bot IO (CofreeBot StateF) Text Text
 bot process = S.applySerializer (sequenceBot $ bot' process) (sequenceSer serializer')


### PR DESCRIPTION
Adds a basic Todo List bot behavior, resolving #44:

```
<<< 📝 podcast-guests create
>>> List Created
<<< 📝 podcast-guests 📝 masaeedu
>>> List Updated
<<< 📝 podcast-guests 📝 boarders
>>> List Updated
<<< 📝 podcast-guests
>>> podcast-guests:
0. masaeedu
1. boarders
```

```
<<< list podcast-guests create
>>> List Created
<<< list podcast-guests add masaeedu
>>> List Updated
<<< list podcast-guests add boarders
>>> List Updated
<<< list podcast-guests
>>> podcast-guests:
0. masaeedu
1. boarders
```

TODO:
- [x] Pretty Printer for list output.
- [x] Multiple lists indexed by strings (ala sessionization of the calculator bot).
- [x] Finalize API
