### PR TITLE
Bot Test Scripts

### DIFF
--- a/cofree-bot.cabal
+++ b/cofree-bot.cabal
@@ -8,6 +8,8 @@ author:        Solomon, Asad, and the Cofree-Coffee community
 maintainer:    ssbothwell@gmail.com
 category:      bot, chat-bot, finite-state-machines, matrix
 
+--------------------------------------------------------------------------------
+
 common common-settings
   default-language:   Haskell2010
   default-extensions:
@@ -42,6 +44,8 @@ common common-settings
     -Wpartial-fields
     -Werror=missing-home-modules
 
+--------------------------------------------------------------------------------
+
 common common-libraries
   build-depends:
     , base           >=2 && <5
@@ -68,6 +72,8 @@ executable cofree-bot
     , xdg-basedir
 
   other-modules:  OptionsParser
+
+--------------------------------------------------------------------------------
 
 library
   import:
@@ -109,3 +115,29 @@ library
     , random
     , vector
     , xdg-basedir
+
+--------------------------------------------------------------------------------
+
+test-suite cofree-bot-test
+  import:
+    , common-libraries
+    , common-settings
+
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Spec.hs
+
+  build-depends:
+    , attoparsec
+    , cofree-bot
+    , data-fix
+    , hspec
+    , hspec-core
+    , lens
+    , mtl
+    , parsec
+    , template-haskell
+
+  other-modules:
+    Scripts
+    TestServer

--- a/src/CofreeBot/Bot/Behaviors/Calculator.hs
+++ b/src/CofreeBot/Bot/Behaviors/Calculator.hs
@@ -32,10 +32,10 @@ parseErrorBot = pureStatelessBot $ \ParseError {..} ->
 
 simplifyCalculatorBot ::
   Monad m =>
-  Bot m s Program (Either CalcError CalcResp) ->
+  Bot m s Statement (CalcError \/ CalcResp) ->
   Bot m s T.Text T.Text
 simplifyCalculatorBot bot =
-  dimap parseProgram indistinct $ parseErrorBot \/ rmap printCalcOutput bot
+  dimap parseStatement indistinct $ parseErrorBot \/ rmap printCalcOutput bot
 
 printCalcOutput :: Either CalcError CalcResp -> T.Text
 printCalcOutput = \case

--- a/src/CofreeBot/Bot/Behaviors/Calculator/Language.hs
+++ b/src/CofreeBot/Bot/Behaviors/Calculator/Language.hs
@@ -15,7 +15,6 @@ import Data.Char
   ( isAlpha,
     isDigit,
   )
-import Data.Foldable
 import Data.Functor
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as Map

--- a/src/CofreeBot/Bot/Behaviors/Calculator/Language.hs
+++ b/src/CofreeBot/Bot/Behaviors/Calculator/Language.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS -fdefer-typed-holes -Wno-orphans #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 
 module CofreeBot.Bot.Behaviors.Calculator.Language where
@@ -15,6 +16,10 @@ import Data.Char
   ( isAlpha,
     isDigit,
   )
+#if __GLASGOW_HASKELL__ >= 902
+#else
+import Data.Foldable
+#endif
 import Data.Functor
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as Map

--- a/src/CofreeBot/Bot/Behaviors/Calculator/Language.hs
+++ b/src/CofreeBot/Bot/Behaviors/Calculator/Language.hs
@@ -115,6 +115,9 @@ data ParseError = ParseError
     parseError :: T.Text
   }
 
+parseStatement :: T.Text -> Either ParseError Statement
+parseStatement txt = first (ParseError txt . T.pack) $ parseOnly statementP txt
+
 parseProgram :: T.Text -> Either ParseError Program
 parseProgram txt = first (ParseError txt . T.pack) $ parseOnly programP txt
 

--- a/test/Scripts.hs
+++ b/test/Scripts.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Scripts
+  ( Script (..),
+    mkScript,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Control.Applicative (asum)
+import Control.Monad (void)
+import Data.Attoparsec.Text
+  ( Parser,
+    endOfInput,
+    isEndOfLine,
+    many',
+    many1,
+    parseOnly,
+    satisfy,
+    skipSpace,
+    takeWhile1,
+  )
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Language.Haskell.TH.Quote (QuasiQuoter (..))
+import Language.Haskell.TH.Syntax (Lift)
+
+--------------------------------------------------------------------------------
+
+newtype Script = Script [(Text, [Text])]
+  deriving stock (Lift)
+  deriving newtype (Show, Read, Eq, Ord)
+
+end :: Parser ()
+end = asum [void (satisfy isEndOfLine), endOfInput]
+
+line :: Parser Text
+line = takeWhile1 (not . isEndOfLine) <* end
+
+inputOutputs :: Parser (Text, [Text])
+inputOutputs = do
+  skipSpace
+  input <- ">>>" *> line
+  outputs <- many' (skipSpace *> "<<<" *> line)
+  pure (input, outputs)
+
+parseScript :: Parser Script
+parseScript = Script <$> many1 inputOutputs
+
+mkScript :: QuasiQuoter
+mkScript =
+  QuasiQuoter {quoteExp, quotePat, quoteType, quoteDec}
+  where
+    quotePat _ = error "'script' does not support quoting patterns"
+    quoteType _ = error "'script' does not support quoting types"
+    quoteDec _ = error "'script' does not support quoting declarations"
+    quoteExp str = case parseOnly parseScript (Text.pack str) of
+      Left _err -> error $ str <> " is not a valid script"
+      Right result -> [|result|]

--- a/test/Scripts.hs
+++ b/test/Scripts.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
@@ -11,7 +12,11 @@ where
 
 --------------------------------------------------------------------------------
 
+#if __GLASGOW_HASKELL__ >= 902
 import Control.Applicative (asum)
+#else
+import Data.Foldable (asum)
+#endif
 import Control.Monad (void)
 import Data.Attoparsec.Text
   ( Parser,

--- a/test/Scripts.hs
+++ b/test/Scripts.hs
@@ -14,6 +14,15 @@ where
 import Control.Applicative (asum)
 import Control.Monad (void)
 import Data.Attoparsec.Text
+  ( Parser,
+    endOfInput,
+    isEndOfLine,
+    many1,
+    parseOnly,
+    satisfy,
+    skipSpace,
+    takeWhile1,
+  )
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Language.Haskell.TH.Quote (QuasiQuoter (..))

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -98,3 +98,38 @@ sessionizedBotSpec =
             |]
       result <- runTestScript scenario $ fixBot bot mempty
       result `shouldBe` scenario
+
+    it "preserves bot behavior" $ do
+      let scenario =
+            [mkScript|
+            >>>new
+            <<<Session Started: '0'.
+            >>>use 0: (1 + 2)  
+            <<<Session '0' Output:
+            1 + 2 = 3
+            |]
+      result <- runTestScript scenario $ fixBot bot mempty
+      result `shouldBe` scenario
+
+    it "tracks multiple sessions" $ do
+      let scenario =
+            [mkScript|
+            >>>new
+            <<<Session Started: '0'.
+            >>>new
+            <<<Session Started: '1'.
+            >>>use 0: x := (1 + 2)  
+            <<<Session '0' Output:
+            *variable saved*
+            >>>use 1: x := 42
+            <<<Session '1' Output:
+            *variable saved*
+            >>>use 0: x
+            <<<Session '0' Output:
+            "x" = 3
+            >>>use 1: x
+            <<<Session '1' Output:
+            "x" = 42
+            |]
+      result <- runTestScript scenario $ fixBot bot mempty
+      result `shouldBe` scenario

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,135 +1,148 @@
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Main where
 
 --------------------------------------------------------------------------------
 
-import CofreeBot.Bot (fixBot)
-import CofreeBot.Bot.Behaviors
+import CofreeBot.Bot (Behavior, Bot (..), fixBot)
+import CofreeBot.Bot.Behaviors.Calculator
   ( calculatorBot,
-    helloSimpleBot,
     printCalcOutput,
     simplifyCalculatorBot,
   )
 import CofreeBot.Bot.Behaviors.Calculator.Language (statementP)
+import CofreeBot.Bot.Behaviors.Hello (helloSimpleBot)
 import CofreeBot.Bot.Context (sessionize, simplifySessionBot)
-import Scripts (mkScript)
-import Test.Hspec (Spec, describe, hspec, it, shouldBe)
-import TestServer (runTestScript)
+import Data.Text (Text, pack)
+import Scripts (Script, mkScript)
+import Test.Hspec (Spec, describe, hspec, it, shouldNotBe)
+import TestServer (Completion (..), conformsToScript, conformsToScript')
 
 --------------------------------------------------------------------------------
 
 main :: IO ()
 main = hspec $ do
+  scriptedTestsSpec
   helloBotSpec
   calculatorBotSpec
   sessionizedBotSpec
+
+scriptedTestsSpec :: Spec
+scriptedTestsSpec = describe "Scripted tests" $ do
+  let myBehavior :: forall m. Monad m => Behavior m Text Text
+      myBehavior = flip fixBot True $ Bot $ \s _ -> return (pack $ show s, not s)
+
+  it "can deal with bots that respond correctly" $ do
+    myBehavior
+      `conformsToScript` [mkScript|
+      >>>hello
+      <<<True
+      >>>whatever
+      <<<False
+      |]
+
+  it "can deal with bots that respond incorrectly" $ do
+    let script :: Script
+        script =
+          [mkScript|
+                 >>>hello
+                 <<<True
+                 >>>whatever
+                 <<<True
+                 |]
+    result <- myBehavior `conformsToScript'` script
+    result `shouldNotBe` Passed
 
 helloBotSpec :: Spec
 helloBotSpec =
   describe "Hello Bot" $ do
     let bot = helloSimpleBot
     it "responds to precisely its trigger phrase" $ do
-      let scenario =
-            [mkScript|
-            >>>cofree-bot
-            <<<Are you talking to me, punk?
-            |]
-      result <- runTestScript scenario $ fixBot bot ()
-      result `shouldBe` scenario
+      fixBot bot ()
+        `conformsToScript` [mkScript|
+        >>>cofree-bot
+        <<<Are you talking to me, punk?
+        |]
 
     it "responds to its trigger phrase embedded in a sentence" $ do
-      let scenario =
-            [mkScript|
-            >>>hows it going cofree-bot
-            <<<Are you talking to me, punk?
-            |]
-      result <- runTestScript scenario $ fixBot bot ()
-      result `shouldBe` scenario
+      fixBot bot ()
+        `conformsToScript` [mkScript|
+        >>>hows it going cofree-bot
+        <<<Are you talking to me, punk?
+        |]
 
 calculatorBotSpec :: Spec
 calculatorBotSpec =
   describe "Calculator Bot" $ do
     let bot = simplifyCalculatorBot calculatorBot
     it "performs arithmetic" $ do
-      let scenario =
-            [mkScript|
-            >>>(1 + 2)
-            <<<1 + 2 = 3
-            >>>(2 * 3)
-            <<<2 * 3 = 6
-            >>>((2 * 3) + 1)
-            <<<2 * 3 + 1 = 7
-            |]
-      result <- runTestScript scenario $ fixBot bot mempty
-      result `shouldBe` scenario
+      fixBot bot mempty
+        `conformsToScript` [mkScript|
+        >>>(1 + 2)
+        <<<1 + 2 = 3
+        >>>(2 * 3)
+        <<<2 * 3 = 6
+        >>>((2 * 3) + 1)
+        <<<2 * 3 + 1 = 7
+        |]
 
     it "can store values in state" $ do
-      let scenario =
-            [mkScript|
-            >>>x := (1 + 2)
-            <<<*variable saved*
-            >>>x
-            <<<"x" = 3
-            |]
-      result <- runTestScript scenario $ fixBot bot mempty
-      result `shouldBe` scenario
+      fixBot bot mempty
+        `conformsToScript` [mkScript|
+        >>>x := (1 + 2)
+        <<<*variable saved*
+        >>>x
+        <<<"x" = 3
+        |]
 
 sessionizedBotSpec :: Spec
 sessionizedBotSpec =
   describe "Sessionized Bot" $ do
     let bot = simplifySessionBot printCalcOutput statementP $ sessionize mempty $ calculatorBot
     it "can instantiate a session" $ do
-      let scenario =
-            [mkScript|
-            >>>new
-            <<<Session Started: '0'.
-            |]
-      result <- runTestScript scenario $ fixBot bot mempty
-      result `shouldBe` scenario
+      fixBot bot mempty
+        `conformsToScript` [mkScript|
+        >>>new
+        <<<Session Started: '0'.
+        |]
 
     it "can delete a session" $ do
-      let scenario =
-            [mkScript|
-            >>>new
-            <<<Session Started: '0'.
-            >>>end 0
-            <<<Session Ended: '0'.
-            |]
-      result <- runTestScript scenario $ fixBot bot mempty
-      result `shouldBe` scenario
+      fixBot bot mempty
+        `conformsToScript` [mkScript|
+        >>>new
+        <<<Session Started: '0'.
+        >>>end 0
+        <<<Session Ended: '0'.
+        |]
 
     it "preserves bot behavior" $ do
-      let scenario =
-            [mkScript|
-            >>>new
-            <<<Session Started: '0'.
-            >>>use 0: (1 + 2)  
-            <<<Session '0' Output:
-            1 + 2 = 3
-            |]
-      result <- runTestScript scenario $ fixBot bot mempty
-      result `shouldBe` scenario
+      fixBot bot mempty
+        `conformsToScript` [mkScript|
+        >>>new
+        <<<Session Started: '0'.
+        >>>use 0: (1 + 2)
+        <<<Session '0' Output:
+        1 + 2 = 3
+        |]
 
     it "tracks multiple sessions" $ do
-      let scenario =
-            [mkScript|
-            >>>new
-            <<<Session Started: '0'.
-            >>>new
-            <<<Session Started: '1'.
-            >>>use 0: x := (1 + 2)  
-            <<<Session '0' Output:
-            *variable saved*
-            >>>use 1: x := 42
-            <<<Session '1' Output:
-            *variable saved*
-            >>>use 0: x
-            <<<Session '0' Output:
-            "x" = 3
-            >>>use 1: x
-            <<<Session '1' Output:
-            "x" = 42
-            |]
-      result <- runTestScript scenario $ fixBot bot mempty
-      result `shouldBe` scenario
+      fixBot bot mempty
+        `conformsToScript` [mkScript|
+        >>>new
+        <<<Session Started: '0'.
+        >>>new
+        <<<Session Started: '1'.
+        >>>use 0: x := (1 + 2)
+        <<<Session '0' Output:
+        *variable saved*
+        >>>use 1: x := 42
+        <<<Session '1' Output:
+        *variable saved*
+        >>>use 0: x
+        <<<Session '0' Output:
+        "x" = 3
+        >>>use 1: x
+        <<<Session '1' Output:
+        "x" = 42
+        |]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Main where
+
+--------------------------------------------------------------------------------
+
+import CofreeBot.Bot (fixBot)
+import CofreeBot.Bot.Behaviors.Calculator
+  ( calculatorBot,
+    simplifyCalculatorBot,
+  )
+import CofreeBot.Bot.Behaviors.Hello (helloSimpleBot)
+import Scripts (mkScript)
+import Test.Hspec (Spec, describe, hspec, it, shouldBe)
+import TestServer (runTestScript)
+
+--------------------------------------------------------------------------------
+
+main :: IO ()
+main = hspec $ do
+  helloBotSpec
+  calculatorBotSpec
+
+helloBotSpec :: Spec
+helloBotSpec =
+  describe "Hello Bot" $ do
+    it "responds to precisely its trigger phrase" $ do
+      let scenario =
+            [mkScript|
+            >>>cofree-bot
+            <<<Are you talking to me, punk?
+            |]
+      result <- runTestScript scenario $ fixBot helloSimpleBot ()
+      result `shouldBe` scenario
+
+    it "responds to its trigger phrase embedded in a sentence" $ do
+      let scenario =
+            [mkScript|
+            >>>hows it going cofree-bot
+            <<<Are you talking to me, punk?
+            |]
+      result <- runTestScript scenario $ fixBot helloSimpleBot ()
+      result `shouldBe` scenario
+
+calculatorBotSpec :: Spec
+calculatorBotSpec =
+  describe "Calculator Bot" $ do
+    it "performs arithmetic" $ do
+      let scenario =
+            [mkScript|
+            >>>(1 + 2)
+            <<<1 + 2 = 3
+            >>>(2 * 3)
+            <<<2 * 3 = 6
+            >>>((2 * 3) + 1)
+            <<<2 * 3 + 1 = 7
+            |]
+      result <- runTestScript scenario $ fixBot (simplifyCalculatorBot calculatorBot) mempty
+      result `shouldBe` scenario
+
+    it "can store values in state" $ do
+      let scenario =
+            [mkScript|
+            >>>x := (1 + 2)
+            <<<*variable saved*
+            >>>x
+            <<<"x" = 3
+            |]
+      result <- runTestScript scenario $ fixBot (simplifyCalculatorBot calculatorBot) mempty
+      result `shouldBe` scenario

--- a/test/TestServer.hs
+++ b/test/TestServer.hs
@@ -1,0 +1,84 @@
+module TestServer
+  ( runTestScript,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import CofreeBot.Bot
+  ( Behavior (Behavior),
+    Server (..),
+    liftBehavior,
+    loop,
+  )
+import CofreeBot.Utils.ListT
+import Control.Monad.Except
+  ( ExceptT,
+    MonadError (..),
+    MonadTrans (..),
+    runExceptT,
+  )
+import Control.Monad.State
+  ( MonadState,
+    StateT (..),
+    gets,
+    modify,
+  )
+import Data.Fix (Fix (..))
+import Data.Text (Text)
+import Scripts
+
+--------------------------------------------------------------------------------
+
+nextInput :: Monad m => StateT ([i], [(i, [o])]) m (Maybe i)
+nextInput =
+  gets fst >>= \case
+    [] -> pure Nothing
+    (i : xs) -> do
+      modify $ \(_, os) -> (xs, os)
+      pure (Just i)
+
+logResult :: Monad m => i -> [o] -> StateT ([i], [(i, [o])]) m ()
+logResult i os = modify $ \(inputs, results) -> (inputs, results <> [(i, os)])
+
+-- | A 'Server' which feeds a pre-programed series of inputs into
+-- its paired bot.
+testServer :: Monad m => Server (StateT ([i], [(i, [o])]) m) o (Maybe i)
+testServer =
+  Server $ do
+    nextInput >>= \case
+      Nothing -> pure $ (Nothing, const $ Server $ runServer $ testServer)
+      Just input -> do
+        pure $ (Just input,) $ \os -> Server $ do
+          logResult input os
+          runServer $ testServer
+
+type MaybeT m = ExceptT () m
+
+boundedAnnihilation ::
+  MonadState (([i], [(i, [o])])) m =>
+  Server m o (Maybe i) ->
+  Behavior m i o ->
+  Fix (MaybeT m)
+boundedAnnihilation (Server server) b@(Behavior botBehavior) = Fix $ do
+  lift server >>= \case
+    (Nothing, _nextServer) -> throwError ()
+    (Just i, nextServer) -> do
+      xs <- lift $ fromListT $ botBehavior i
+      let o = fmap fst xs
+          server' = nextServer o
+      pure $ boundedAnnihilation server' $ case xs of
+        [] -> b
+        _ -> snd (last xs)
+
+runTestScript :: Script -> Behavior IO Text Text -> IO Script
+runTestScript (Script script) bot =
+  fmap (Script . snd . snd) $
+    flip runStateT (inputs, []) $
+      runExceptT $
+        loop $
+          boundedAnnihilation
+            testServer
+            (liftBehavior bot)
+  where
+    inputs = fmap fst script

--- a/test/TestServer.hs
+++ b/test/TestServer.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-partial-fields #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
@@ -12,32 +11,19 @@ where
 
 --------------------------------------------------------------------------------
 
+import CofreeBot (Behavior)
 import CofreeBot.Bot
-  ( Behavior (Behavior),
-    Env (..),
+  ( Env (..),
     Server (..),
     annihilate,
     fixEnv,
     hoistBehavior,
-    hoistBot,
-    hoistServer,
-    liftBehavior,
-    loop,
   )
-import CofreeBot.Utils.ListT
 import Control.Monad.Except
-  ( ExceptT,
-    MonadError (..),
+  ( MonadError (..),
     MonadTrans (..),
     liftEither,
     runExceptT,
-  )
-import Control.Monad.IO.Class
-import Control.Monad.State
-  ( MonadState,
-    StateT (..),
-    gets,
-    modify,
   )
 import Data.Fix (Fix (..))
 import Data.List.NonEmpty (NonEmpty (..), nonEmpty)


### PR DESCRIPTION
Resolves #8 

Conversational bot integration tests such as:

```haskell
calculatorBotSpec :: Spec
calculatorBotSpec =
  describe "Calculator Bot" $ do
    let bot = simplifyCalculatorBot calculatorBot
    it "performs arithmetic" $ do
      let scenario =
            [mkScript|
            >>>(1 + 2)
            <<<1 + 2 = 3
            >>>(2 * 3)
            <<<2 * 3 = 6
            >>>((2 * 3) + 1)
            <<<2 * 3 + 1 = 7
            |]
      result <- runTestScript scenario $ fixBot bot mempty
      result `shouldBe` scenario
```

I'm really happy with this API but the internal implementation of the test server could  use some work:
```
testServer :: Monad m => Server (StateT ([i], [(i, [o])]) m) o (Maybe i)
```

I store the remaining inputs and the result as `([i], [(i, [o])])` in `State` and produce a `Maybe i` for the next input to indicate when we have reached the end of the script. Is `State` a good choice here?

We need to have a way to short circuit the annihilation step when we hit the end of the script. AFAICT this requires a special cased `annihilation` function. I would love it if this isn't needed.