### PR TITLE
[Executable] Use an HKD to fetch bot config from env, argv, and config file.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,37 +1,40 @@
 {-# LANGUAGE NumDecimals #-}
-{-# OPTIONS_GHC -Wno-missing-signatures #-}
 
 module Main where
 
+--------------------------------------------------------------------------------
+
 import CofreeBot
-import CofreeBot.Bot.Behaviors.Calculator.Language
-import Control.Monad
-import Control.Monad.Except
-  ( ExceptT,
-    runExceptT,
-  )
+import CofreeBot.Bot.Behaviors.Calculator.Language (statementP)
+import Control.Monad (void, (>=>))
+import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Monad.IO.Class (liftIO)
-import Data.Foldable
+import Data.Foldable (fold)
 import GHC.Conc (threadDelay)
-import Network.Matrix.Client
+import Network.Matrix.Client (ClientSession, login)
+import Options
 import Options.Applicative qualified as Opt
-import OptionsParser
 import System.Environment.XDG.BaseDir (getUserCacheDir)
-import System.Process.Typed
+import System.Process.Typed (getStdout, withProcessWait_)
+
+--------------------------------------------------------------------------------
 
 main :: IO ()
 main = do
-  command <- Opt.execParser parserInfo
   xdgCache <- getUserCacheDir "cofree-bot"
-
-  case command of
+  Opt.execParser parserInfo >>= \case
     LoginCmd cred -> do
       session <- login cred
       matrixMain session xdgCache
-    TokenCmd TokenCredentials {..} -> do
-      session <- createSession (getMatrixServer matrixServer) matrixToken
-      matrixMain session xdgCache
+    TokenCmd clientSessionArgv -> do
+      clientSessionEnv <- fromEnv
+      clientSessionConfigFile <- fromConfig
+      toClientSession (fold [clientSessionArgv, clientSessionEnv, clientSessionConfigFile]) >>= \case
+        Just session -> matrixMain session xdgCache
+        Nothing -> error "Invaid Client Session"
     CLI -> cliMain xdgCache
+
+--------------------------------------------------------------------------------
 
 bot process =
   let calcBot =
@@ -51,6 +54,8 @@ bot process =
         /.\ updogMatrixBot
         /.\ liftSimpleBot jitsiBot
 
+--------------------------------------------------------------------------------
+
 cliMain :: FilePath -> IO ()
 cliMain xdgCache = withProcessWait_ ghciConfig $ \process -> do
   void $ threadDelay 1e6
@@ -58,6 +63,8 @@ cliMain xdgCache = withProcessWait_ ghciConfig $ \process -> do
   state <- readState xdgCache
   fixedBot <- flip (fixBotPersistent xdgCache) (fold state) $ simplifyMatrixBot $ bot process
   void $ loop $ annihilate repl fixedBot
+
+--------------------------------------------------------------------------------
 
 unsafeCrashInIO :: Show e => ExceptT e IO a -> IO a
 unsafeCrashInIO = runExceptT >=> either (fail . show) pure

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -1,0 +1,14 @@
+module Options
+  ( module Config,
+    module Env,
+    module Parser,
+    module Types,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Options.Config as Config
+import Options.Env as Env
+import Options.Parser as Parser
+import Options.Types as Types

--- a/app/Options/Config.hs
+++ b/app/Options/Config.hs
@@ -1,0 +1,42 @@
+-- | Subroutine for fetching Client Session data from a config file.
+module Options.Config
+  ( fromConfig,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Control.Monad (void)
+import Data.Aeson qualified as Aeson
+import Data.Functor.Barbie
+import Options.Types
+import System.Directory (createDirectoryIfMissing, doesFileExist)
+import System.Environment.XDG.BaseDir (getUserConfigDir)
+import System.FilePath
+
+--------------------------------------------------------------------------------
+-- XDG Config
+
+readJSON :: IO (Maybe Aeson.Value)
+readJSON = do
+  configDir <- getUserConfigDir "cofree-bot"
+  void $ createDirectoryIfMissing True configDir
+  let path = configDir </> "config"
+  doesFileExist path >>= \case
+    True -> Aeson.decodeFileStrict path
+    False -> pure Nothing
+
+fromConfig :: IO (ClientSessionF Maybe)
+fromConfig = do
+  readJSON
+    >>= pure . \case
+      Nothing -> bpure Nothing
+      Just json -> fromResult (bpure Nothing) $ Aeson.fromJSON json
+
+result :: b -> (a -> b) -> Aeson.Result a -> b
+result b f = \case
+  Aeson.Success a -> f a
+  Aeson.Error _ -> b
+
+fromResult :: a -> Aeson.Result a -> a
+fromResult a = result a id

--- a/app/Options/Config.hs
+++ b/app/Options/Config.hs
@@ -8,8 +8,9 @@ where
 
 import Control.Monad (void)
 import Data.Aeson qualified as Aeson
-import Data.Functor.Barbie
-import Options.Types
+import Data.Functor.Barbie (bpure)
+import Data.Yaml qualified as Yaml
+import Options.Types (ClientSessionF)
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.Environment.XDG.BaseDir (getUserConfigDir)
 import System.FilePath
@@ -23,7 +24,7 @@ readJSON = do
   void $ createDirectoryIfMissing True configDir
   let path = configDir </> "config"
   doesFileExist path >>= \case
-    True -> Aeson.decodeFileStrict path
+    True -> Yaml.decodeFileThrow path
     False -> pure Nothing
 
 fromConfig :: IO (ClientSessionF Maybe)

--- a/app/Options/Env.hs
+++ b/app/Options/Env.hs
@@ -1,0 +1,28 @@
+-- | Subroutine for fetching Client Session data from the Environment.
+module Options.Env
+  ( fromEnv,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Functor.Barbie
+import Data.Functor.Compose
+import Options.Types
+import System.Environment (lookupEnv)
+import Text.Read (readMaybe)
+
+--------------------------------------------------------------------------------
+-- Env
+
+readEnv :: Read a => String -> (IO `Compose` Maybe) a
+readEnv envKey =
+  Compose $ lookupEnv envKey >>= pure . maybe Nothing readMaybe
+
+fromEnv :: IO (ClientSessionF Maybe)
+fromEnv =
+  bsequence $
+    ClientSessionF
+      { matrixServer = readEnv "COFREE_BOT_MATRIX_SERVER",
+        matrixToken = readEnv "COFREE_BOT_MATRIX_TOKEN"
+      }

--- a/app/Options/Types.hs
+++ b/app/Options/Types.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Options.Types
+  ( ClientSessionF (..),
+    toClientSession,
+    MatrixServer (..),
+    MatrixToken (..),
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Control.Applicative
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson qualified as Aeson
+import Data.Coerce (coerce)
+import Data.Functor.Barbie
+  ( AllBF,
+    ApplicativeB,
+    ConstraintsB,
+    FunctorB,
+    Rec (Rec),
+    TraversableB,
+    bpure,
+    bzipWith,
+  )
+import Data.Text (Text)
+import GHC.Generics (Generic, M1 (M1))
+import Network.Matrix.Client
+  ( ClientSession,
+    MatrixToken (..),
+    createSession,
+  )
+
+--------------------------------------------------------------------------------
+
+newtype MonoidB b f = MonoidB (b f)
+
+instance (ApplicativeB b, Alternative f) => Semigroup (MonoidB b f) where
+  MonoidB t1 <> MonoidB t2 = MonoidB $ bzipWith (<|>) t1 t2
+
+instance (ApplicativeB b, Alternative f) => Monoid (MonoidB b f) where
+  mempty = MonoidB $ bpure empty
+
+--------------------------------------------------------------------------------
+
+data ClientSessionF f = ClientSessionF
+  { matrixServer :: f MatrixServer,
+    matrixToken :: f MatrixToken
+  }
+  deriving stock (Generic)
+  deriving anyclass (FunctorB, ApplicativeB, TraversableB, ConstraintsB)
+  deriving (Semigroup, Monoid) via (MonoidB ClientSessionF f)
+
+deriving instance (AllBF Aeson.FromJSON f ClientSessionF) => Aeson.FromJSON (ClientSessionF f)
+
+toClientSession :: ClientSessionF Maybe -> IO (Maybe ClientSession)
+toClientSession ClientSessionF {..} = do
+  sequence $ liftA2 createSession (coerce matrixServer) matrixToken
+
+--------------------------------------------------------------------------------
+
+newtype MatrixServer = MatrixServer {getMatrixServer :: Text}
+  deriving newtype (Read, FromJSON, ToJSON)
+
+instance FromJSON MatrixToken where
+  parseJSON = Aeson.withText "MatrixToken" (pure . MatrixToken)
+
+deriving newtype instance Read MatrixToken

--- a/cofree-bot.cabal
+++ b/cofree-bot.cabal
@@ -65,6 +65,7 @@ executable cofree-bot
     , mtl
     , optparse-applicative
     , xdg-basedir
+    , yaml
 
   other-modules:
     , Options

--- a/cofree-bot.cabal
+++ b/cofree-bot.cabal
@@ -57,12 +57,21 @@ executable cofree-bot
   main-is:        Main.hs
   hs-source-dirs: app
   build-depends:
+    , aeson
+    , barbies
     , cofree-bot
+    , directory
+    , filepath
     , mtl
     , optparse-applicative
     , xdg-basedir
 
-  other-modules:  OptionsParser
+  other-modules:
+    , Options
+    , Options.Env
+    , Options.Config
+    , Options.Types
+    , Options.Parser
 
 library
   import:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,10 @@ services:
   cofree-bot:
     image: ghcr.io/cofree-coffee/cofree-bot:latest
     environment:
-      - AUTH_TOKEN=$AUTH_TOKEN
+      - COFREE_BOT_MATRIX_TOKEN=$COFREE_BOT_MATRIX_TOKEN
+      - COFREE_BOT_MATRIX_SERVER=$COFREE_BOT_MATRIX_SERVER
       - XDG_CACHE_HOME=/cache
+      - XDG_CONFIG_HOME=/config
     deploy:
       restart_policy:
         condition: on-failure
@@ -12,6 +14,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /root/.docker/config.json:/config.json
       - bot_cache:/cache
+      - bot_config:/config
   watchtower:
     image: containrrr/watchtower
     volumes:
@@ -23,3 +26,4 @@ services:
         condition: on-failure
 volumes:
   bot_cache:
+  bot_config:

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -13,7 +13,7 @@ pkgs.dockerTools.buildLayeredImage {
     Entrypoint = "${pkgs.bash}/bin/bash";
     Cmd = [
       "-c"
-      "${pkgs.haskell.lib.justStaticExecutables cofree-bot}/bin/cofree-bot run --auth_token $AUTH_TOKEN --homeserver https://matrix.cofree.coffee"
+      "${pkgs.haskell.lib.justStaticExecutables cofree-bot}/bin/cofree-bot run"
     ];
   };
 }


### PR DESCRIPTION
**work in progress**

Resolves #11 

Allows bot configuration to be provided from Env, Argv, or an XDG config file (currently json).

```haskell
data ClientSessionF f = ClientSessionF
  { matrixServer :: f MatrixServer,
    matrixToken :: f MatrixToken
  }
```
This only impacts our executable, which is a matrix specific example bot. I think config management should be outside the scope of the library. 