### PR TITLE
Fix Session Parser Bug

### DIFF
--- a/chat-bots-contrib/test/Spec.hs
+++ b/chat-bots-contrib/test/Spec.hs
@@ -142,3 +142,11 @@ sessionizedBotSpec =
         <<<Session '1' Output:
         "x" = 42
         |]
+
+    it "ignores bodies of text beginning with session keywords" $ do
+      fixBot bot mempty
+        `conformsToScript` [mkScript|
+        >>>new body of text that happens to begin with the word new
+        >>>use body of text that begins with the word use
+        >>>end body of text that begins with the word end
+        |]

--- a/chat-bots/src/Data/Chat/Bot/Context.hs
+++ b/chat-bots/src/Data/Chat/Bot/Context.hs
@@ -134,7 +134,9 @@ sessionizedParser :: (Text -> Maybe i) -> Parser (SessionInput i)
 sessionizedParser p = do
   keyword <- New <$ "new" <|> Use <$ "use" <|> End <$ "end"
   case keyword of
-    New -> pure StartSession
+    New -> do
+      _ <- endOfInput <|> endOfLine
+      pure StartSession
     Use -> do
       _ <- space
       n <- decimal <* ": "


### PR DESCRIPTION
Previously:
```haskell
it "would instantiate a session with any text beginning with the keyword 'new'" $ do
  fixBot bot mempty
    `conformsToScript` [mkScript|
    >>>new body of text that happens to begin with the word 'new'
    <<<Session Started: '0'.
    |]
```

With the proposed changes:
```haskell
it "ignores bodies of text beginning with session keywords" $ do
  fixBot bot mempty
    `conformsToScript` [mkScript|
    >>>new body of text that happens to begin with the word new
    >>>use body of text that begins with the word use
    >>>end body of text that begins with the word end
    |]
```