### PR TITLE
Enables name shadowing and fixes HLS version in Nix Flake

### DIFF
--- a/chat-bots-contrib/src/Data/Chat/Bot/Updog.hs
+++ b/chat-bots-contrib/src/Data/Chat/Bot/Updog.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Data.Chat.Bot.Updog
   ( -- * Bot
     updogBot,
@@ -11,7 +13,9 @@ where
 
 --------------------------------------------------------------------------------
 
+#if !MIN_VERSION_base(4,18,0)
 import Control.Applicative (liftA2)
+#endif
 import Control.Monad.ListT (toListT)
 import Data.Chat.Bot
 import Data.Chat.Bot.Serialization

--- a/chat-bots/chat-bots.cabal
+++ b/chat-bots/chat-bots.cabal
@@ -42,6 +42,7 @@ common common-settings
     -Wincomplete-uni-patterns
     -Wpartial-fields
     -Werror=missing-home-modules
+    -Wno-name-shadowing
 
 --------------------------------------------------------------------------------
 

--- a/chat-bots/src/Control/Monad/ListT.hs
+++ b/chat-bots/src/Control/Monad/ListT.hs
@@ -25,7 +25,11 @@ where
 
 --------------------------------------------------------------------------------
 
+#if MIN_VERSION_base(4,18,0)
+import Control.Applicative (Alternative (..))
+#else
 import Control.Applicative (Alternative (..), Applicative (..))
+#endif
 import Control.Monad (ap)
 #if MIN_VERSION_base(4,18,0)
 import Control.Monad.Except (MonadError (..))

--- a/chat-bots/src/Data/Chat/Bot.hs
+++ b/chat-bots/src/Data/Chat/Bot.hs
@@ -38,11 +38,12 @@ import Control.Monad.ListT (ListF (..), ListT (..), emptyListT, hoistListT)
 import Control.Monad.Reader (MonadReader, ReaderT (..))
 import Control.Monad.State (MonadState, StateT (..))
 import Control.Monad.Trans (MonadTrans (..))
-import Data.Align
 import Data.Bifunctor (Bifunctor (..))
 import Data.Bifunctor.Monoidal qualified as Bifunctor
 import Data.Chat.Utils (readFileMaybe)
-#if MIN_VERSION_base(4,16,1)
+#if MIN_VERSION_base(4,18,0)
+import Control.Applicative (asum)
+#elif MIN_VERSION_base(4,16,1)
 import Control.Applicative (asum, liftA2)
 #else
 import Control.Applicative (liftA2)

--- a/chat-bots/src/Data/Chat/Bot/Monoidal.hs
+++ b/chat-bots/src/Data/Chat/Bot/Monoidal.hs
@@ -15,12 +15,10 @@ where
 --------------------------------------------------------------------------------
 
 import Control.Monad.ListT (toListT)
-import Data.Align
-import Data.Bifunctor.Monoidal.Specialized (split')
 import Data.Chat.Bot (Bot (..))
 import Data.Chat.Utils (type (/+\), type (/\), type (\*/), type (\/))
 import Data.Functor.Monoidal qualified as Functor
-import Data.Profunctor (Profunctor (..), Strong (..))
+import Data.Profunctor (Strong (..))
 import Data.These (These (..))
 import Data.Trifunctor.Monoidal ((|***|))
 import Data.Trifunctor.Monoidal qualified as Trifunctor

--- a/chat-bots/src/Data/Chat/Bot/Serialization.hs
+++ b/chat-bots/src/Data/Chat/Bot/Serialization.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- | Bidirectional parsing to map 'Bot' I/O to 'Server' I/O.
 --
 -- TODO: Make monoidal-functor instances
@@ -5,7 +7,9 @@ module Data.Chat.Bot.Serialization where
 
 --------------------------------------------------------------------------------
 
+#if !MIN_VERSION_base(4,18,0)
 import Control.Applicative (liftA2)
+#endif
 import Control.Monad ((>=>))
 import Control.Monad.ListT (emptyListT)
 import Data.Attoparsec.Text qualified as P
@@ -47,7 +51,7 @@ prefix prefix' Serializer {..} =
           printer = printer
         }
 
-infixr 6 /+\
+infixr 6 /+\\
 
 (/+\) :: TextSerializer o i -> TextSerializer o' i' -> TextSerializer (o /+\ o') (i /+\ i')
 (/+\) (Serializer par1 pri1) (Serializer par2 pri2) = Serializer (par1 *|* par2) (pri1 +|+ pri2)

--- a/chat-bots/src/Data/Chat/Utils.hs
+++ b/chat-bots/src/Data/Chat/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 module Data.Chat.Utils
@@ -28,7 +29,9 @@ where
 
 -------------------------------------------------------------------------------
 
-import Control.Applicative
+#if !MIN_VERSION_base(4,18,0)
+import Control.Applicative (liftA2)
+#endif
 import Control.Arrow ((&&&))
 import Control.Exception (catch, throwIO)
 import Data.Kind
@@ -41,7 +44,7 @@ import System.IO.Error (isDoesNotExistError)
 
 type (/\) = (,)
 
-infixr 6 /\
+infixr 6 /\\
 
 pattern (:&) :: a -> b -> (a, b)
 pattern a :& b = (a, b)
@@ -71,7 +74,7 @@ infixr 6 \*/
 
 type a /+\ b = These a b
 
-infixr 6 /+\
+infixr 6 /+\\
 
 can :: Maybe a -> Maybe b -> Maybe (a /+\ b)
 can Nothing Nothing = Nothing

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
                 cabal-install
                 ghcid
                 haskell.compiler.${compiler}
-                haskell-language-server
+                haskell.packages.${compiler}.haskell-language-server
                 just
                 pkg-config
                 ormolu


### PR DESCRIPTION
#88 updated us to GHC9.8.2 but was using `HLS` from `haskellPackages` which was still pinned to GHC9.6.5. This PR switches us to whatever version of HLS matches our compiler. It also fixes all GHC warnings and allows name shadowing.