### PR TITLE
Factor out machine coalgebra library

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,7 @@ packages: chat-bots
 packages: chat-bots-contrib 
 packages: cofree-bot
 packages: list-t
+packages: machines-coalgebras
                     
 source-repository-package
   type: git
@@ -12,4 +13,4 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/solomon-b/monoidal-functors.git
-  tag: eeb61da953592b7c01ab319b14f961e8f04c82c0
+  tag: e951a2be496d57d7f4e5b582ad175e8e97a9ab7b

--- a/chat-bots-contrib/chat-bots-contrib.cabal
+++ b/chat-bots-contrib/chat-bots-contrib.cabal
@@ -52,6 +52,7 @@ common common-libraries
     , bytestring
     , filepath
     , list-t
+    , machines-coalgebras
     , matrix-client
     , network-uri
     , profunctors
@@ -118,7 +119,6 @@ test-suite chat-bots-contrib-test
     , hspec-core
     , lens
     , list-t
-    , machines-coalgebras
     , mtl
     , parsec
     , template-haskell

--- a/chat-bots-contrib/chat-bots-contrib.cabal
+++ b/chat-bots-contrib/chat-bots-contrib.cabal
@@ -117,6 +117,8 @@ test-suite chat-bots-contrib-test
     , hspec
     , hspec-core
     , lens
+    , list-t
+    , machines-coalgebras
     , mtl
     , parsec
     , template-haskell

--- a/chat-bots-contrib/src/Data/Chat/Server/Matrix.hs
+++ b/chat-bots-contrib/src/Data/Chat/Server/Matrix.hs
@@ -16,8 +16,8 @@ import Control.Monad.Except
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Chat.Bot
 import Data.Chat.Bot.Serialization
-import Data.Chat.Server
 import Data.Chat.Utils (readFileMaybe)
+import Data.Machine.Moore (MooreM' (..))
 import Data.Map.Strict qualified as Map
 import Data.Profunctor
 import Data.Text (Text)
@@ -34,14 +34,14 @@ type MatrixBot m s = Bot m s (RoomID, Event) (RoomID, Event)
 liftMatrixIO :: (MonadIO m, MonadError MatrixError m) => MatrixIO x -> m x
 liftMatrixIO m = liftEither =<< liftIO m
 
--- | A Matrix 'Server' for connecting a 'Bot' to the Matrix protocol.
+-- | A Matrix Server for connecting a 'Bot' to the Matrix protocol.
 matrix ::
   forall m.
   (MonadError MatrixError m, MonadIO m) =>
   ClientSession ->
   FilePath ->
-  Server m (RoomID, Event) [(RoomID, Event)]
-matrix session cache = Server $ do
+  MooreM' m [(RoomID, Event)] [(RoomID, Event)]
+matrix session cache = MooreM' $ do
   -- Setup cache
   liftIO $ createDirectoryIfMissing True cache
   since <- liftIO $ readFileMaybe $ cache <> "/since_file"
@@ -51,10 +51,10 @@ matrix session cache = Server $ do
   filterId <- liftMatrixIO $ createFilter session userId messageFilter
 
   -- Start looping
-  runServer $ go filterId since
+  runMooreM' $ go filterId since
   where
-    go :: FilterID -> Maybe Text -> Server m (RoomID, Event) [(RoomID, Event)]
-    go filterId since = Server $ do
+    go :: FilterID -> Maybe Text -> MooreM' m [(RoomID, Event)] [(RoomID, Event)]
+    go filterId since = MooreM' $ do
       -- Get conversation events
       syncResult <-
         liftMatrixIO $
@@ -77,7 +77,7 @@ matrix session cache = Server $ do
               roomEvents
 
       pure $
-        (events,) $ \outputs -> Server $ do
+        (events,) $ \outputs -> MooreM' $ do
           -- Send the bot's responses
           gen <- newStdGen
           let txnIds = TxnID . Text.pack . show <$> randoms @Int gen
@@ -87,7 +87,7 @@ matrix session cache = Server $ do
           liftIO $ writeFile (cache <> "/since_file") (Text.unpack newSince)
 
           -- Do it again
-          runServer $ go filterId (Just newSince)
+          runMooreM' $ go filterId (Just newSince)
 
 embedTextBot :: (Applicative m) => Bot m s Text Text -> Bot m s (RoomID, Event) (RoomID, Event)
 embedTextBot = second' . flip applySerializer eventSerializer

--- a/chat-bots-contrib/test/Spec.hs
+++ b/chat-bots-contrib/test/Spec.hs
@@ -11,7 +11,7 @@ import Data.Chat.Bot.Calculator
 import Data.Chat.Bot.Context (sessionSerializer, sessionize)
 import Data.Chat.Bot.Hello
 import Data.Chat.Bot.Serialization qualified as S
-import Data.Machine.Mealy (MealyM')
+import Data.Machine.Mealy (MealyT)
 import Data.Text (Text, pack)
 import Scripts (Script, mkScript)
 import Test.Hspec (Spec, describe, hspec, it, shouldNotBe)
@@ -28,7 +28,7 @@ main = hspec $ do
 
 scriptedTestsSpec :: Spec
 scriptedTestsSpec = describe "Scripted tests" $ do
-  let myBehavior :: forall m. (Monad m) => MealyM' (ListT m) Text Text
+  let myBehavior :: forall m. (Monad m) => MealyT (ListT m) Text Text
       myBehavior = flip fixBot True $ Bot $ \s _ -> return (pack $ show s, not s)
 
   it "can deal with bots that respond correctly" $ do

--- a/chat-bots-contrib/test/Spec.hs
+++ b/chat-bots-contrib/test/Spec.hs
@@ -5,11 +5,13 @@ module Main where
 
 --------------------------------------------------------------------------------
 
-import Data.Chat.Bot (Behavior, Bot (..), fixBot)
+import Control.Monad.ListT (ListT)
+import Data.Chat.Bot (Bot (..), fixBot)
 import Data.Chat.Bot.Calculator
 import Data.Chat.Bot.Context (sessionSerializer, sessionize)
 import Data.Chat.Bot.Hello
 import Data.Chat.Bot.Serialization qualified as S
+import Data.Machine.Mealy (MealyM')
 import Data.Text (Text, pack)
 import Scripts (Script, mkScript)
 import Test.Hspec (Spec, describe, hspec, it, shouldNotBe)
@@ -26,7 +28,7 @@ main = hspec $ do
 
 scriptedTestsSpec :: Spec
 scriptedTestsSpec = describe "Scripted tests" $ do
-  let myBehavior :: forall m. (Monad m) => Behavior m Text Text
+  let myBehavior :: forall m. (Monad m) => MealyM' (ListT m) Text Text
       myBehavior = flip fixBot True $ Bot $ \s _ -> return (pack $ show s, not s)
 
   it "can deal with bots that respond correctly" $ do

--- a/chat-bots-contrib/test/TestServer.hs
+++ b/chat-bots-contrib/test/TestServer.hs
@@ -20,13 +20,13 @@ import Control.Monad.ListT (ListT, hoistListT)
 import Control.Monad.Trans (MonadTrans (..))
 import Data.Chat.Server
   ( Env (..),
-    Server (..),
     annihilate,
     fixEnv,
   )
 import Data.Fix (Fix (..))
 import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import Data.Machine.Mealy (MealyM', hoistMealyM')
+import Data.Machine.Moore (MooreM')
 import Data.Text (Text)
 import Data.Void
 import Scripts
@@ -49,7 +49,7 @@ initReplayServerState (Script interactions) = case interactions of
 replayServer ::
   (Eq o, MonadError (Completion i o) m) =>
   ReplayServerState i o ->
-  Server m o i
+  MooreM' m [o] i
 replayServer = fixEnv $ Env $ (liftEither .) $ \case
   Left completion -> Left completion
   Right (Interaction prompt expectedResponses :| rest) -> Right $ (prompt,) $ \actualResponses ->

--- a/chat-bots-contrib/test/TestServer.hs
+++ b/chat-bots-contrib/test/TestServer.hs
@@ -26,7 +26,7 @@ import Data.Chat.Server
 import Data.Fix (Fix (..))
 import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import Data.Machine.Mealy (MealyT, hoistMealyT)
-import Data.Machine.Moore (MooreM')
+import Data.Machine.Moore (MooreT)
 import Data.Text (Text)
 import Data.Void
 import Scripts
@@ -49,7 +49,7 @@ initReplayServerState (Script interactions) = case interactions of
 replayServer ::
   (Eq o, MonadError (Completion i o) m) =>
   ReplayServerState i o ->
-  MooreM' m [o] i
+  MooreT m [o] i
 replayServer = fixEnv $ Env $ (liftEither .) $ \case
   Left completion -> Left completion
   Right (Interaction prompt expectedResponses :| rest) -> Right $ (prompt,) $ \actualResponses ->

--- a/chat-bots/chat-bots.cabal
+++ b/chat-bots/chat-bots.cabal
@@ -51,6 +51,7 @@ common common-libraries
     , base           >=2 && <5
     , bytestring
     , list-t
+    , machines-coalgebras
     , matrix-client
     , monoidal-functors
     , network-uri

--- a/chat-bots/src/Data/Chat/Bot.hs
+++ b/chat-bots/src/Data/Chat/Bot.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 -- | The core Chat Bot encoding.
 module Data.Chat.Bot
@@ -23,12 +24,10 @@ module Data.Chat.Bot
     saveState,
 
     -- * Behavior
-    Behavior (..),
+    MealyM' (..),
 
     -- ** Operations
     batch,
-    hoistBehavior,
-    liftBehavior,
   )
 where
 
@@ -37,10 +36,8 @@ where
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.ListT (ListF (..), ListT (..), emptyListT, hoistListT)
 import Control.Monad.Reader (MonadReader)
-import Control.Monad.State (MonadState, StateT (..))
-import Control.Monad.Trans (MonadTrans (..))
+import Control.Monad.State (MonadState)
 import Data.Bifunctor (Bifunctor (..))
-import Data.Bifunctor.Monoidal qualified as Bifunctor
 import Data.Chat.Utils (readFileMaybe)
 #if MIN_VERSION_base(4,18,0)
 import Control.Applicative (asum)
@@ -50,17 +47,19 @@ import Control.Applicative (asum, liftA2)
 import Control.Applicative (liftA2)
 import Data.Foldable (asum)
 #endif
+import Control.Category (Category (..))
 import Data.Functor ((<&>))
 import Data.Kind
-import Data.Profunctor (Choice (..), Profunctor (..), Strong (..))
-import Data.Profunctor.Traversing (Traversing (..))
+import Data.Machine.Mealy (MealyM' (..))
+import Data.Machine.Mealy.Coalgebra (MealyM (..), fixMealyM)
+import Data.Profunctor (Profunctor (..), Strong (..))
 import Data.Text qualified as Text
 import Data.These (These (..))
 import Data.Trifunctor.Monoidal qualified as Trifunctor
 import Data.Void (Void)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
-import Data.Machine.Mealy.Coalgebra (MealyM (..))
+import Prelude hiding (id, (.))
 
 --------------------------------------------------------------------------------
 
@@ -113,6 +112,8 @@ deriving via (MealyM (ListT f) s) instance (Functor f) => Profunctor (Bot f s)
 
 deriving via (MealyM (ListT f) s) instance (Functor f) => Strong (Bot f s)
 
+deriving via (MealyM (ListT m) s) instance (Monad m) => Category (Bot m s)
+
 -- | 'Bot' is an invariant functor on @s@ but our types don't quite
 -- fit the @Invariant@ typeclass.
 invmapBot :: (Functor m) => (s -> s') -> (s' -> s) -> Bot m s i o -> Bot m s' i o
@@ -145,26 +146,22 @@ liftEffect m = Bot $ \s _ -> ListT $ do
   o <- m
   pure $ ConsF (o, s) (ListT $ pure NilF)
 
--- | Generate the fixed point of @Bot m s i o@ by recursively
--- construction an @s -> Behavior m i o@ action and tupling it with
--- the output @o@ from its parent action.
-fixBot :: forall m s i o. (Functor m) => Bot m s i o -> s -> Behavior m i o
-fixBot (Bot b) = go
-  where
-    go :: s -> Behavior m i o
-    go s = Behavior $ \i -> second go <$> b s i
+-- | Generate the fixed point of @Bot m s i o@ by recursively construction an @s
+-- -> MealyM' (ListT m) i o@ action and tupling it with the output @o@ from its
+-- parent action.
+fixBot :: forall m s i o. (Functor m) => Bot m s i o -> s -> MealyM' (ListT m) i o
+fixBot = fixMealyM . MealyM . runBot
 
 -- TODO: A bi-parser typeclass
 type Serializable a = (Read a, Show a)
 
--- | A variation of 'fixBot' where the bot's state is persisted to disk.
-fixBotPersistent :: forall m s i o. (MonadIO m, Serializable s) => FilePath -> Bot m s i o -> s -> IO (Behavior m i o)
+fixBotPersistent :: forall m s i o. (MonadIO m, Serializable s) => FilePath -> Bot m s i o -> s -> IO (MealyM' (ListT m) i o)
 fixBotPersistent cachePath (Bot bot) initialState = do
   saveState cachePath initialState
   pure go
   where
-    go :: Behavior m i o
-    go = Behavior $ \i ->
+    go :: MealyM' (ListT m) i o
+    go = MealyM' $ \i ->
       liftIO (readState cachePath) >>= \case
         Nothing -> error "ERROR: Failed to read Bot State from disk."
         Just oldState -> do
@@ -184,66 +181,7 @@ saveState cachePath state' = do
 
 --------------------------------------------------------------------------------
 
--- | The fixed point of a 'Bot'.
---
--- Notice that the @s@ parameter has disapeared. This allows us to
--- hide the state threading when interpreting a 'Bot' with some 'Env'.
---
--- See 'annihilate' for how this interaction occurs in practice.
-newtype Behavior m i o = Behavior {runBehavior :: i -> ListT m (o, (Behavior m i o))}
-
-instance (Functor m) => Profunctor (Behavior m) where
-  dimap :: (Functor m) => (a -> b) -> (c -> d) -> Behavior m b c -> Behavior m a d
-  dimap f g (Behavior b) = Behavior $ dimap f (fmap (bimap g (dimap f g))) b
-
-instance (Monad m) => Bifunctor.Semigroupal (->) (,) (,) (,) (Behavior m) where
-  combine :: (Behavior m i o, Behavior m i' o') -> Behavior m (i, i') (o, o')
-  combine (Behavior m1, Behavior m2) = Behavior $ \(i, i') -> do
-    liftA2 (uncurry (\o m1' (o', m2') -> ((o, o'), Bifunctor.combine (m1', m2')))) (m1 i) (m2 i')
-
-instance (Monad m) => Bifunctor.Unital (->) () () () (Behavior m) where
-  introduce :: () -> Behavior m () ()
-  introduce () = Behavior $ \() -> pure ((), Bifunctor.introduce ())
-
-instance (Monad m) => Bifunctor.Monoidal (->) (,) () (,) () (,) () (Behavior m)
-
-instance (Monad m) => Choice (Behavior m) where
-  left' :: (Monad m) => Behavior m a b -> Behavior m (Either a c) (Either b c)
-  left' (Behavior b) =
-    Behavior $
-      either
-        (fmap (bimap Left left') . b)
-        (pure . (,left' (Behavior b)) . Right)
-
-instance (Functor m) => Strong (Behavior m) where
-  first' :: (Functor m) => Behavior m a b -> Behavior m (a, c) (b, c)
-  first' (Behavior b) = Behavior $ \(a, c) -> fmap (bimap (,c) first') (b a)
-
-instance (Monad m) => Traversing (Behavior m) where
-  -- TODO: write wander instead for efficiency
-  traverse' :: (Monad m, Traversable f) => Behavior m a b -> Behavior m (f a) (f b)
-  traverse' b = Behavior $ \is ->
-    fmap (uncurry (,) . fmap traverse') $
-      flip runStateT b $
-        traverse
-          ( \i -> StateT $ \(Behavior b') ->
-              fmap (\(responses, nextState) -> (responses, nextState)) $ b' i
-          )
-          is
-
---------------------------------------------------------------------------------
-
 -- | Batch process a list of inputs @i@ with a single 'Behavior',
 -- interleaving the effects, and collecting the resulting outputs @o@.
-batch :: (Monad m) => Behavior m i o -> Behavior m [i] o
-batch (Behavior b) = Behavior $ fmap (fmap batch) . asum . fmap b
-
--- | Lift a monad morphism from @m@ to @n@ into a monad morphism from
--- @Behavior m s i o@ to @Behavior n s i o@
-hoistBehavior :: (Functor n, Functor m) => (forall x. m x -> n x) -> Behavior m i o -> Behavior n i o
-hoistBehavior f (Behavior b) = Behavior $ \i -> hoistListT f $ fmap (fmap (hoistBehavior f)) $ b i
-
--- | Lift a computation on the monad @m@ to the constructed monad @t
--- m@ in the context of a 'Behavior'.
-liftBehavior :: (Functor (t m), Monad m, MonadTrans t) => Behavior m i o -> Behavior (t m) i o
-liftBehavior = hoistBehavior lift
+batch :: (Monad m) => MealyM' (ListT m) i o -> MealyM' (ListT m) [i] o
+batch (MealyM' b) = MealyM' $ fmap (fmap batch) . asum . fmap b

--- a/chat-bots/src/Data/Chat/Server.hs
+++ b/chat-bots/src/Data/Chat/Server.hs
@@ -18,11 +18,11 @@ where
 
 --------------------------------------------------------------------------------
 
-import Control.Monad.ListT (fromListT)
+import Control.Monad.ListT (ListT, fromListT)
 import Control.Monad.Trans.Class (MonadTrans (..))
 import Data.Bifunctor (bimap)
-import Data.Chat.Bot (Behavior (..))
 import Data.Fix (Fix (..))
+import Data.Machine.Mealy (MealyM' (..))
 import Data.Profunctor (Profunctor (..))
 
 --------------------------------------------------------------------------------
@@ -88,10 +88,10 @@ liftServer = hoistServer lift
 
 -- | Collapse a @Server m o i@ with a @Bahavior m i o@ to create a
 -- monadic action @m@.
-annihilate :: (Monad m) => Server m o i -> Behavior m i o -> Fix m
-annihilate (Server server) b@(Behavior botBehavior) = Fix $ do
+annihilate :: (Monad m) => Server m o i -> MealyM' (ListT m) i o -> Fix m
+annihilate (Server server) b@(MealyM' mealy) = Fix $ do
   (i, nextServer) <- server
-  xs <- fromListT $ botBehavior i
+  xs <- fromListT $ mealy i
   let o = fmap fst $ xs
       server' = nextServer o
   pure $

--- a/chat-bots/src/Data/Chat/Server.hs
+++ b/chat-bots/src/Data/Chat/Server.hs
@@ -18,7 +18,7 @@ where
 import Control.Monad.ListT (ListT, fromListT)
 import Data.Bifunctor (bimap)
 import Data.Fix (Fix (..))
-import Data.Machine.Mealy (MealyM' (..))
+import Data.Machine.Mealy (MealyT (..))
 import Data.Machine.Moore (MooreM' (..))
 import Data.Machine.Moore.Coalgebra (MooreM (..), fixMooreM)
 import Data.Profunctor (Profunctor (..))
@@ -60,8 +60,8 @@ fixEnv = fixMooreM . MooreM . runEnv
 
 -- | Collapse a @Server m o i@ with a @Bahavior m i o@ to create a
 -- monadic action @m@.
-annihilate :: (Monad m) => MooreM' m [o] i -> MealyM' (ListT m) i o -> Fix m
-annihilate (MooreM' server) b@(MealyM' mealy) = Fix $ do
+annihilate :: (Monad m) => MooreM' m [o] i -> MealyT (ListT m) i o -> Fix m
+annihilate (MooreM' server) b@(MealyT mealy) = Fix $ do
   (i, nextServer) <- server
   xs <- fromListT $ mealy i
   let o = fmap fst $ xs

--- a/chat-bots/src/Data/Chat/Server.hs
+++ b/chat-bots/src/Data/Chat/Server.hs
@@ -7,10 +7,7 @@ module Data.Chat.Server
     fixEnv,
     hoistEnv,
 
-    -- * Server
-    Server (..),
-    hoistServer,
-    liftServer,
+    -- * Execution
     annihilate,
     loop,
   )
@@ -19,10 +16,11 @@ where
 --------------------------------------------------------------------------------
 
 import Control.Monad.ListT (ListT, fromListT)
-import Control.Monad.Trans.Class (MonadTrans (..))
 import Data.Bifunctor (bimap)
 import Data.Fix (Fix (..))
 import Data.Machine.Mealy (MealyM' (..))
+import Data.Machine.Moore (MooreM' (..))
+import Data.Machine.Moore.Coalgebra (MooreM (..), fixMooreM)
 import Data.Profunctor (Profunctor (..))
 
 --------------------------------------------------------------------------------
@@ -52,44 +50,18 @@ instance (Functor m) => Profunctor (Env m s) where
 hoistEnv :: (Functor n) => (forall x. m x -> n x) -> Env m s o i -> Env n s o i
 hoistEnv f (Env env) = Env $ \s -> f $ env s
 
---------------------------------------------------------------------------------
-
--- | The fixed point of an 'Env'. Like in 'Behavior' we have factored
--- out the @s@ parameter to hide the state threading.
---
--- See 'annihilate' for how this interaction occurs in practice.
-newtype Server m o i = Server {runServer :: m (i, [o] -> Server m o i)}
-  deriving (Functor)
-
-instance (Functor m) => Profunctor (Server m) where
-  dimap f g (Server serve) =
-    Server $ fmap (bimap g (dimap (fmap f) (dimap f g))) serve
-
 -- | Generate the fixed point of @Env m s o i@ by recursively
 -- construction an @s -> Server m o i@ action and tupling it with
 -- the output @i@ from its parent action.
-fixEnv :: forall m s o i. (Functor m) => Env m s o i -> s -> Server m o i
-fixEnv (Env b) = go
-  where
-    go :: s -> Server m o i
-    go s = Server $ fmap (fmap (fmap go)) $ b s
-
--- | Lift a monad morphism from @m@ to @n@ into a monad morphism from
--- @Env m s o i@ to @Env n s o i@
-hoistServer :: (Functor n) => (forall x. m x -> n x) -> Server m o i -> Server n o i
-hoistServer f (Server server) = Server $ fmap (fmap (fmap (hoistServer f))) $ f server
-
--- | Lift a computation on the monad @m@ to the constructed monad @t
--- m@ in the context of a 'Server'.
-liftServer :: (Functor (t m), Monad m, MonadTrans t) => Server m o i -> Server (t m) o i
-liftServer = hoistServer lift
+fixEnv :: forall m s o i. (Functor m) => Env m s o i -> s -> MooreM' m [o] i
+fixEnv = fixMooreM . MooreM . runEnv
 
 --------------------------------------------------------------------------------
 
 -- | Collapse a @Server m o i@ with a @Bahavior m i o@ to create a
 -- monadic action @m@.
-annihilate :: (Monad m) => Server m o i -> MealyM' (ListT m) i o -> Fix m
-annihilate (Server server) b@(MealyM' mealy) = Fix $ do
+annihilate :: (Monad m) => MooreM' m [o] i -> MealyM' (ListT m) i o -> Fix m
+annihilate (MooreM' server) b@(MealyM' mealy) = Fix $ do
   (i, nextServer) <- server
   xs <- fromListT $ mealy i
   let o = fmap fst $ xs

--- a/chat-bots/src/Data/Chat/Server/Repl.hs
+++ b/chat-bots/src/Data/Chat/Server/Repl.hs
@@ -10,7 +10,7 @@ where
 
 import Control.Monad (forM_)
 import Control.Monad.IO.Class (MonadIO (..))
-import Data.Machine.Moore (MooreM' (..))
+import Data.Machine.Moore (MooreT (..))
 import Data.Text (Text)
 import Data.Text qualified as Text
 import System.IO (hFlush, stdout)
@@ -18,8 +18,8 @@ import System.IO (hFlush, stdout)
 --------------------------------------------------------------------------------
 
 -- | A repl-style 'Server' for interacting with a 'Bot'.
-repl :: MooreM' IO [Text] Text
-repl = MooreM' $ do
+repl :: MooreT IO [Text] Text
+repl = MooreT $ do
   -- Read the user's input
   liftIO $ do
     putStr "<<< "
@@ -27,10 +27,10 @@ repl = MooreM' $ do
   (Text.pack -> input) <- liftIO getLine
 
   pure $
-    (input,) $ \outputs -> MooreM' $ do
+    (input,) $ \outputs -> MooreT $ do
       forM_ outputs $ \output -> do
         -- Print the bot's responses
         liftIO $ putStrLn $ Text.unpack $ ">>> " <> output
 
       -- Do it again
-      runMooreM' repl
+      runMooreT repl

--- a/chat-bots/src/Data/Chat/Server/Repl.hs
+++ b/chat-bots/src/Data/Chat/Server/Repl.hs
@@ -10,7 +10,7 @@ where
 
 import Control.Monad (forM_)
 import Control.Monad.IO.Class (MonadIO (..))
-import Data.Chat.Server (Server (..))
+import Data.Machine.Moore (MooreM' (..))
 import Data.Text (Text)
 import Data.Text qualified as Text
 import System.IO (hFlush, stdout)
@@ -18,8 +18,8 @@ import System.IO (hFlush, stdout)
 --------------------------------------------------------------------------------
 
 -- | A repl-style 'Server' for interacting with a 'Bot'.
-repl :: Server IO Text Text
-repl = Server $ do
+repl :: MooreM' IO [Text] Text
+repl = MooreM' $ do
   -- Read the user's input
   liftIO $ do
     putStr "<<< "
@@ -27,10 +27,10 @@ repl = Server $ do
   (Text.pack -> input) <- liftIO getLine
 
   pure $
-    (input,) $ \outputs -> Server $ do
+    (input,) $ \outputs -> MooreM' $ do
       forM_ outputs $ \output -> do
         -- Print the bot's responses
         liftIO $ putStrLn $ Text.unpack $ ">>> " <> output
 
       -- Do it again
-      runServer repl
+      runMooreM' repl

--- a/flake.nix
+++ b/flake.nix
@@ -33,11 +33,12 @@
             chat-bots-contrib = hfinal.callCabal2nix "chat-bots" ./chat-bots-contrib/. { };
             cofree-bot = hfinal.callCabal2nix "cofree-bot" ./cofree-bot/. { };
             list-t = hfinal.callCabal2nix "list-t" ./list-t/. { };
+            machines-coalgebras = hfinal.callCabal2nix "list-t" ./machines-coalgebras/. { };
             monoidal-functors = hfinal.callCabal2nix "monoidal-functors" (pkgs.fetchFromGitHub {
               owner = "solomon-b";
               repo = "monoidal-functors";
-              rev = "eeb61da953592b7c01ab319b14f961e8f04c82c0";
-              sha256 = "sha256-XnSffGuRTzr5LCrxu8x7AU3hmNk314Ip2ky2Z9xRJI0=";
+              rev = "e951a2be496d57d7f4e5b582ad175e8e97a9ab7b";
+              sha256 = "sha256-HfIMuU9yBp0JtN/ONOFku1wItbGLJl09fhaFzyiNVMg=";
             }) { };
           };
         };

--- a/machines-coalgebras/machines-coalgebras.cabal
+++ b/machines-coalgebras/machines-coalgebras.cabal
@@ -44,6 +44,7 @@ common common-settings
 common common-libraries
   build-depends:
     , base           >=2 && <5
+    , data-fix
     , monoidal-functors
     , profunctors
     , these
@@ -57,6 +58,7 @@ library
 
   hs-source-dirs:  src
   exposed-modules:
+    Data.Machine
     Data.Machine.Mealy
     Data.Machine.Mealy.Coalgebra
     Data.Machine.Mealy.Coalgebra.Monoidal

--- a/machines-coalgebras/machines-coalgebras.cabal
+++ b/machines-coalgebras/machines-coalgebras.cabal
@@ -45,6 +45,7 @@ common common-libraries
   build-depends:
     , base           >=2 && <5
     , data-fix
+    , machines
     , monoidal-functors
     , profunctors
     , these

--- a/machines-coalgebras/machines-coalgebras.cabal
+++ b/machines-coalgebras/machines-coalgebras.cabal
@@ -1,0 +1,69 @@
+cabal-version: 3.0
+name:          machines-coalgebras
+version:       0.1.0.0
+synopsis:      Coalgebraic encoding of Mealy and Moore machines
+bug-reports:   https://github.com/cofree-coffee/cofree-bot
+license:       MIT
+author:        Solomon, Asad, and the Cofree-Coffee community
+maintainer:    ssbothwell@gmail.com
+category:      finite-state-machines, coalgebras, streaming
+
+--------------------------------------------------------------------------------
+
+common common-settings
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFunctor
+    DerivingVia
+    FlexibleContexts
+    FlexibleInstances
+    ImportQualifiedPost
+    InstanceSigs
+    LambdaCase
+    MultiParamTypeClasses
+    OverloadedStrings
+    RankNTypes
+    ScopedTypeVariables
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    ViewPatterns
+
+  ghc-options:
+    -Wall
+    -Wcpp-undef
+    -Widentities
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wpartial-fields
+    -Werror=missing-home-modules
+    -Wno-name-shadowing
+
+--------------------------------------------------------------------------------
+
+common common-libraries
+  build-depends:
+    , base           >=2 && <5
+    , monoidal-functors
+    , profunctors
+    , these
+
+--------------------------------------------------------------------------------
+
+library
+  import:
+    , common-libraries
+    , common-settings
+
+  hs-source-dirs:  src
+  exposed-modules:
+    Data.Machine.Mealy
+    Data.Machine.Mealy.Coalgebra
+    Data.Machine.Mealy.Coalgebra.Monoidal
+    Data.Machine.Moore
+    Data.Machine.Moore.Coalgebra
+    Data.Machine.Moore.Coalgebra.Monoidal
+
+  build-depends:
+    , bifunctors
+    , mtl

--- a/machines-coalgebras/src/Data/Machine.hs
+++ b/machines-coalgebras/src/Data/Machine.hs
@@ -1,0 +1,30 @@
+module Data.Machine
+  ( module M,
+    Fix (..),
+    annihilate,
+    loop,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Data.Fix (Fix (..))
+import Data.Machine.Mealy as M
+import Data.Machine.Moore as M
+
+--------------------------------------------------------------------------------
+
+-- | "An Ay^B Mealy Machine is the 'universal thing' that interacts
+-- with a By^A Moore Machine. Its the universal thing that can be put
+-- together with a By^A Moore Machine. They're not just two different
+-- definitions, they are dual in certain sense." -- David Spivak
+annihilate :: (Monad m) => MooreM' m o i -> MealyM' m i o -> Fix m
+annihilate (MooreM' moore) (MealyM' mealy) = Fix $ do
+  (i, nextMoore) <- moore
+  (o, mealy') <- mealy i
+  let moore' = nextMoore o
+  pure $ annihilate moore' mealy'
+
+-- | Recursively unfold fixed point @Fix m@.
+loop :: (Monad f) => Fix f -> f x
+loop (Fix x) = x >>= loop

--- a/machines-coalgebras/src/Data/Machine.hs
+++ b/machines-coalgebras/src/Data/Machine.hs
@@ -18,8 +18,8 @@ import Data.Machine.Moore as M
 -- with a By^A Moore Machine. Its the universal thing that can be put
 -- together with a By^A Moore Machine. They're not just two different
 -- definitions, they are dual in certain sense." -- David Spivak
-annihilate :: (Monad m) => MooreM' m o i -> MealyT m i o -> Fix m
-annihilate (MooreM' moore) (MealyT mealy) = Fix $ do
+annihilate :: (Monad m) => MooreT m o i -> MealyT m i o -> Fix m
+annihilate (MooreT moore) (MealyT mealy) = Fix $ do
   (i, nextMoore) <- moore
   (o, mealy') <- mealy i
   let moore' = nextMoore o

--- a/machines-coalgebras/src/Data/Machine.hs
+++ b/machines-coalgebras/src/Data/Machine.hs
@@ -18,8 +18,8 @@ import Data.Machine.Moore as M
 -- with a By^A Moore Machine. Its the universal thing that can be put
 -- together with a By^A Moore Machine. They're not just two different
 -- definitions, they are dual in certain sense." -- David Spivak
-annihilate :: (Monad m) => MooreM' m o i -> MealyM' m i o -> Fix m
-annihilate (MooreM' moore) (MealyM' mealy) = Fix $ do
+annihilate :: (Monad m) => MooreM' m o i -> MealyT m i o -> Fix m
+annihilate (MooreM' moore) (MealyT mealy) = Fix $ do
   (i, nextMoore) <- moore
   (o, mealy') <- mealy i
   let moore' = nextMoore o

--- a/machines-coalgebras/src/Data/Machine/Mealy.hs
+++ b/machines-coalgebras/src/Data/Machine/Mealy.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Data.Machine.Mealy where
+
+--------------------------------------------------------------------------------
+
+#if !MIN_VERSION_base(4,18,0)
+import Control.Applicative (liftA2)
+#endif
+import Control.Category (Category (..))
+import Control.Monad.Trans (MonadTrans (..))
+import Data.Bifunctor (Bifunctor (..))
+import Data.Bifunctor.Monoidal qualified as Bifunctor
+import Data.Functor.Identity (Identity)
+import Data.Profunctor (Choice, Profunctor (..), Strong (..))
+import Data.Profunctor.Choice (Choice (..))
+import Prelude hiding (id, (.))
+
+--------------------------------------------------------------------------------
+
+-- | The fixed point of a 'Mealy' Machine. By taking the fixpoint we
+-- are able to hide the state parameter @s@.
+newtype MealyM' m i o = MealyM' {runMealyM' :: i -> m (o, MealyM' m i o)}
+  deriving stock (Functor)
+
+-- | The fixed point of a 'Mealy' Machine. By taking the fixpoint we
+-- are able to hide the state parameter @s@.
+type Mealy' = MealyM' Identity
+
+instance (Applicative m) => Bifunctor.Semigroupal (->) (,) (,) (,) (MealyM' m) where
+  combine :: (MealyM' m i o, MealyM' m i' o') -> MealyM' m (i, i') (o, o')
+  combine (MealyM' m1, MealyM' m2) = MealyM' $ \(i, i') -> do
+    liftA2 (uncurry (\o m1' (o', m2') -> ((o, o'), Bifunctor.combine (m1', m2')))) (m1 i) (m2 i')
+
+instance (Applicative m) => Bifunctor.Unital (->) () () () (MealyM' m) where
+  introduce :: () -> MealyM' m () ()
+  introduce () = MealyM' $ \() -> pure ((), Bifunctor.introduce ())
+
+instance (Applicative m) => Bifunctor.Monoidal (->) (,) () (,) () (,) () (MealyM' m)
+
+instance (Functor m) => Profunctor (MealyM' m) where
+  dimap :: (i' -> i) -> (o -> o') -> MealyM' m i o -> MealyM' m i' o'
+  dimap f g (MealyM' mealy) = MealyM' $ dimap f (fmap (bimap g (dimap f g))) mealy
+
+instance (Functor m) => Strong (MealyM' m) where
+  first' :: MealyM' m i o -> MealyM' m (i, x) (o, x)
+  first' (MealyM' mealy) = MealyM' $ \(i, x) -> bimap (,x) first' <$> mealy i
+
+instance (Applicative m) => Choice (MealyM' m) where
+  left' :: MealyM' m i o -> MealyM' m (Either i x) (Either o x)
+  left' (MealyM' mealy) = MealyM' $ either (fmap (bimap Left left') . mealy) (pure . (,left' (MealyM' mealy)) . Right)
+
+instance (Monad m) => Category (MealyM' m) where
+  id :: (Monad m) => MealyM' m a a
+  id = MealyM' $ \a ->
+    pure (a, id)
+
+  (.) :: (Monad m) => MealyM' m b c -> MealyM' m a b -> MealyM' m a c
+  MealyM' m2 . MealyM' m1 = MealyM' $ \a -> do
+    (b, m1') <- m1 a
+    (c, m2') <- m2 b
+    pure (c, m2' . m1')
+
+-- | Lift a monad morphism from @m@ to @n@ into a monad morphism from
+-- @MealyM' m s i o@ to @MealyM' n s i o@
+hoistMealyM' :: (Functor n, Functor m) => (forall x. m x -> n x) -> MealyM' m i o -> MealyM' n i o
+hoistMealyM' f (MealyM' mealy) = MealyM' $ \i -> f (fmap (hoistMealyM' f) <$> mealy i)
+
+-- | Lift a computation on the monad @m@ to the constructed monad @t
+-- m@ in the context of a 'MealyM''.
+liftMealyM' :: (Functor (t m), Monad m, MonadTrans t) => MealyM' m i o -> MealyM' (t m) i o
+liftMealyM' = hoistMealyM' lift

--- a/machines-coalgebras/src/Data/Machine/Mealy/Coalgebra.hs
+++ b/machines-coalgebras/src/Data/Machine/Mealy/Coalgebra.hs
@@ -2,15 +2,15 @@
 
 -- | Mealy Machine Coalgebras
 module Data.Machine.Mealy.Coalgebra
-  ( MealyM (..),
-    Mealy,
-    fixMealyM,
+  ( MealyTC (..),
+    MealyC,
+    fixMealyTC,
     fixMealy,
-    scanMealyM,
+    scanMealyTC,
     scanMealy,
-    processMealyM,
+    processMealyTC,
     processMealy,
-    hoistMealyM,
+    hoistMealyTC,
   )
 where
 
@@ -26,7 +26,7 @@ import Control.Monad.Identity (Identity (..))
 import Control.Monad.Reader
 import Control.Monad.State
 import Data.Bifunctor (bimap, first)
-import Data.Machine.Mealy (Mealy', MealyM' (..))
+import Data.Machine.Mealy (Mealy, MealyT (..))
 import Data.Profunctor (Profunctor, Strong (..))
 import Data.Profunctor.Unsafe (Profunctor (..))
 import Data.These
@@ -47,7 +47,7 @@ import Data.Void (Void, absurd)
 --
 -- In this particular encoding combine the @transition@ and @Observe@
 -- functions into @S × I → M (O × S)@. This definition is isomorphic.
-newtype MealyM m s i o = MealyM {runMealy :: s -> i -> m (o, s)}
+newtype MealyTC m s i o = MealyTC {runMealy :: s -> i -> m (o, s)}
   deriving
     (Functor, Applicative, Monad, MonadState s, MonadReader i, MonadIO)
     via StateT s (ReaderT i m)
@@ -63,106 +63,106 @@ newtype MealyM m s i o = MealyM {runMealy :: s -> i -> m (o, s)}
 --
 -- In this particular encoding combine the @transition@ and @Observe@
 -- functions into @S × I → O × S@. This definition is isomorphic.
-type Mealy = MealyM Identity
+type MealyC = MealyTC Identity
 
-instance (Applicative m) => Trifunctor.Semigroupal (->) (,) (,) (,) (,) (MealyM m) where
-  combine :: (MealyM m s i o, MealyM m t i' o') -> MealyM m (s, t) (i, i') (o, o')
-  combine (MealyM m1, MealyM m2) = MealyM $ \(s, t) (i, i') ->
+instance (Applicative m) => Trifunctor.Semigroupal (->) (,) (,) (,) (,) (MealyTC m) where
+  combine :: (MealyTC m s i o, MealyTC m t i' o') -> MealyTC m (s, t) (i, i') (o, o')
+  combine (MealyTC m1, MealyTC m2) = MealyTC $ \(s, t) (i, i') ->
     liftA2 (curry (\((o, s'), (o', t')) -> ((o, o'), (s', t')))) (m1 s i) (m2 t i')
 
-instance (Functor m) => Trifunctor.Semigroupal (->) (,) Either Either (,) (MealyM m) where
-  combine :: (MealyM m s i o, MealyM m t i' o') -> MealyM m (s, t) (Either i i') (Either o o')
-  combine (MealyM m1, MealyM m2) = MealyM $ \(s, t) -> \case
+instance (Functor m) => Trifunctor.Semigroupal (->) (,) Either Either (,) (MealyTC m) where
+  combine :: (MealyTC m s i o, MealyTC m t i' o') -> MealyTC m (s, t) (Either i i') (Either o o')
+  combine (MealyTC m1, MealyTC m2) = MealyTC $ \(s, t) -> \case
     Left i -> (bimap Left (,t) <$> m1 s i)
     Right i' -> bimap Right (s,) <$> m2 t i'
 
-instance (Applicative m) => Trifunctor.Semigroupal (->) (,) These These (,) (MealyM m) where
-  combine :: (MealyM m s i o, MealyM m t i' o') -> MealyM m (s, t) (These i i') (These o o')
-  combine (MealyM m1, MealyM m2) = MealyM $ \(s, t) -> \case
+instance (Applicative m) => Trifunctor.Semigroupal (->) (,) These These (,) (MealyTC m) where
+  combine :: (MealyTC m s i o, MealyTC m t i' o') -> MealyTC m (s, t) (These i i') (These o o')
+  combine (MealyTC m1, MealyTC m2) = MealyTC $ \(s, t) -> \case
     This i -> bimap This (,t) <$> m1 s i
     That i' -> bimap That (s,) <$> m2 t i'
     These i i' -> do
       liftA2 (curry (\((o, s'), (o', t')) -> (These o o', (s', t')))) (m1 s i) (m2 t i')
 
-instance (Applicative m) => Trifunctor.Unital (->) () () () () (MealyM m) where
-  introduce :: () -> MealyM m () () ()
-  introduce () = MealyM $ \() () -> pure ((), ())
+instance (Applicative m) => Trifunctor.Unital (->) () () () () (MealyTC m) where
+  introduce :: () -> MealyTC m () () ()
+  introduce () = MealyTC $ \() () -> pure ((), ())
 
-instance Trifunctor.Unital (->) () Void Void () (MealyM m) where
-  introduce :: () -> MealyM m () Void Void
-  introduce () = MealyM $ \() -> absurd
+instance Trifunctor.Unital (->) () Void Void () (MealyTC m) where
+  introduce :: () -> MealyTC m () Void Void
+  introduce () = MealyTC $ \() -> absurd
 
-instance (Applicative m) => Trifunctor.Monoidal (->) (,) () (,) () (,) () (,) () (MealyM m)
+instance (Applicative m) => Trifunctor.Monoidal (->) (,) () (,) () (,) () (,) () (MealyTC m)
 
-instance (Applicative m) => Trifunctor.Monoidal (->) (,) () Either Void Either Void (,) () (MealyM m)
+instance (Applicative m) => Trifunctor.Monoidal (->) (,) () Either Void Either Void (,) () (MealyTC m)
 
-instance (Applicative m) => Trifunctor.Monoidal (->) (,) () These Void These Void (,) () (MealyM m)
+instance (Applicative m) => Trifunctor.Monoidal (->) (,) () These Void These Void (,) () (MealyTC m)
 
-instance (Functor m) => Profunctor (MealyM m s) where
-  dimap :: (i' -> i) -> (o -> o') -> MealyM m s i o -> MealyM m s i' o'
-  dimap f g (MealyM mealy) = MealyM $ fmap (dimap f (fmap (first g))) mealy
+instance (Functor m) => Profunctor (MealyTC m s) where
+  dimap :: (i' -> i) -> (o -> o') -> MealyTC m s i o -> MealyTC m s i' o'
+  dimap f g (MealyTC mealy) = MealyTC $ fmap (dimap f (fmap (first g))) mealy
 
-instance (Functor m) => Strong (MealyM m s) where
-  first' :: MealyM m s i o -> MealyM m s (i, c) (o, c)
-  first' (MealyM mealy) = MealyM $ \s (i, c) -> first (,c) <$> mealy s i
+instance (Functor m) => Strong (MealyTC m s) where
+  first' :: MealyTC m s i o -> MealyTC m s (i, c) (o, c)
+  first' (MealyTC mealy) = MealyTC $ \s (i, c) -> first (,c) <$> mealy s i
 
-instance (Monad m) => Category (MealyM m s) where
-  id :: (Monad m) => MealyM m s a a
-  id = MealyM $ \s i ->
+instance (Monad m) => Category (MealyTC m s) where
+  id :: (Monad m) => MealyTC m s a a
+  id = MealyTC $ \s i ->
     pure (i, s)
 
-  (.) :: (Monad m) => MealyM m s b c -> MealyM m s a b -> MealyM m s a c
-  MealyM m2 . MealyM m1 = MealyM $ \s a ->
+  (.) :: (Monad m) => MealyTC m s b c -> MealyTC m s a b -> MealyTC m s a c
+  MealyTC m2 . MealyTC m1 = MealyTC $ \s a ->
     m1 s a >>= uncurry m2 . swap
 
 -- | Lift a monad morphism from @m@ to @n@ into a monad morphism from
--- @MealyM m s i o@ to @MealyM n s i o@
-hoistMealyM :: (Functor n) => (forall x. m x -> n x) -> MealyM m s i o -> MealyM n s i o
-hoistMealyM f (MealyM b) = MealyM $ \s i -> f $ b s i
+-- @MealyTC m s i o@ to @MealyTC n s i o@
+hoistMealyTC :: (Functor n) => (forall x. m x -> n x) -> MealyTC m s i o -> MealyTC n s i o
+hoistMealyTC f (MealyTC b) = MealyTC $ \s i -> f $ b s i
 
 --------------------------------------------------------------------------------
 
 -- | Take the fixpoint of @Mealy s i o@ by recursively constructing an
 -- @s -> Mealy' i o@ action adn tupling it with the output observation
 -- @o@ from its parent action.
-fixMealyM :: forall m s i o. (Functor m) => MealyM m s i o -> s -> MealyM' m i o
-fixMealyM (MealyM mealy) = go
+fixMealyTC :: forall m s i o. (Functor m) => MealyTC m s i o -> s -> MealyT m i o
+fixMealyTC (MealyTC mealy) = go
   where
-    go :: s -> MealyM' m i o
-    go s = MealyM' (fmap (second' go) . mealy s)
+    go :: s -> MealyT m i o
+    go s = MealyT (fmap (second' go) . mealy s)
 
--- | Monomorphised 'fixMealyM'.
-fixMealy :: forall s i o. Mealy s i o -> s -> Mealy' i o
-fixMealy = fixMealyM
+-- | Monomorphised 'fixMealyT.
+fixMealy :: forall s i o. MealyC s i o -> s -> Mealy i o
+fixMealy = fixMealyTC
 
 --------------------------------------------------------------------------------
 
 -- | Feed inputs into a 'Mealy' Machine and extract the observation at
 -- each state/input in a 'scan' style.
-scanMealyM :: (Monad m) => s -> [i] -> MealyM m s i o -> m [(o, s)]
-scanMealyM initialState inputs machine =
+scanMealyTC :: (Monad m) => s -> [i] -> MealyTC m s i o -> m [(o, s)]
+scanMealyTC initialState inputs machine =
   case inputs of
     [] -> pure []
     input : xs -> do
       (o, s) <- runMealy machine initialState input
-      ys <- scanMealyM s xs machine
+      ys <- scanMealyTC s xs machine
       pure $ (o, s) : ys
 
--- | Monomorphised 'scanMealyM'.
-scanMealy :: s -> [i] -> Mealy s i o -> [(o, s)]
-scanMealy initialState inputs machine = runIdentity $ scanMealyM initialState inputs machine
+-- | Monomorphised 'scanMealyT.
+scanMealy :: s -> [i] -> MealyC s i o -> [(o, s)]
+scanMealy initialState inputs machine = runIdentity $ scanMealyTC initialState inputs machine
 
 -- | Feed inputs into a 'Mealy' Machine and then observe the final
 -- result.
-processMealyM :: (Monad m) => s -> [i] -> MealyM m s i o -> m o
-processMealyM state' inputs machine =
+processMealyTC :: (Monad m) => s -> [i] -> MealyTC m s i o -> m o
+processMealyTC state' inputs machine =
   case inputs of
     [] -> undefined
     [input] -> fmap fst (runMealy machine state' input)
     input : xs -> do
       (_o, s) <- runMealy machine state' input
-      processMealyM s xs machine
+      processMealyTC s xs machine
 
--- | Monomorphised 'processMealyM'.
-processMealy :: s -> [i] -> Mealy s i o -> o
-processMealy state' inputs machine = runIdentity $ processMealyM state' inputs machine
+-- | Monomorphised 'processMealyT.
+processMealy :: s -> [i] -> MealyC s i o -> o
+processMealy state' inputs machine = runIdentity $ processMealyTC state' inputs machine

--- a/machines-coalgebras/src/Data/Machine/Mealy/Coalgebra.hs
+++ b/machines-coalgebras/src/Data/Machine/Mealy/Coalgebra.hs
@@ -49,7 +49,7 @@ import Data.Void (Void, absurd)
 -- functions into @S × I → M (O × S)@. This definition is isomorphic.
 newtype MealyM m s i o = MealyM {runMealy :: s -> i -> m (o, s)}
   deriving
-    (Functor, Applicative, Monad, MonadState s, MonadReader i)
+    (Functor, Applicative, Monad, MonadState s, MonadReader i, MonadIO)
     via StateT s (ReaderT i m)
 
 -- | A Mealy Machine consists of:

--- a/machines-coalgebras/src/Data/Machine/Mealy/Coalgebra.hs
+++ b/machines-coalgebras/src/Data/Machine/Mealy/Coalgebra.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE CPP #-}
+
+-- | Mealy Machine Coalgebras
+module Data.Machine.Mealy.Coalgebra
+  ( MealyM (..),
+    Mealy,
+    fixMealyM,
+    fixMealy,
+    scanMealyM,
+    scanMealy,
+    processMealyM,
+    processMealy,
+    hoistMealyM,
+  )
+where
+
+--------------------------------------------------------------------------------
+
+#if !MIN_VERSION_base(4,18,0)
+import Control.Applicative (liftA2)
+#endif
+import Control.Category (Category)
+import Control.Category qualified as Category
+import Control.Category.Tensor
+import Control.Monad.Identity (Identity (..))
+import Control.Monad.Reader
+import Control.Monad.State
+import Data.Bifunctor (bimap, first)
+import Data.Machine.Mealy (Mealy', MealyM' (..))
+import Data.Profunctor (Profunctor, Strong (..))
+import Data.Profunctor.Unsafe (Profunctor (..))
+import Data.These
+import Data.Trifunctor.Monoidal qualified as Trifunctor
+import Data.Void (Void, absurd)
+
+--------------------------------------------------------------------------------
+
+-- | A Monadic Mealy Machine consists of:
+--
+--   * A finite set of states @S@
+--   * An initial state @s : S@
+--   * A monad @M@
+--   * A finite set called the input @I@
+--   * A finite set called the output @O@
+--   * A function @transistion : S × I → M S@
+--   * A function @observe : S × I → M O@
+--
+-- In this particular encoding combine the @transition@ and @Observe@
+-- functions into @S × I → M (O × S)@. This definition is isomorphic.
+newtype MealyM m s i o = MealyM {runMealy :: s -> i -> m (o, s)}
+  deriving
+    (Functor, Applicative, Monad, MonadState s, MonadReader i)
+    via StateT s (ReaderT i m)
+
+-- | A Mealy Machine consists of:
+--
+--   * A finite set of states @S@
+--   * An initial state @s : S@
+--   * A finite set called the input @I@
+--   * A finite set called the output @O@
+--   * A function @transistion : S × I → S@
+--   * A function @observe : S × I → O@
+--
+-- In this particular encoding combine the @transition@ and @Observe@
+-- functions into @S × I → O × S@. This definition is isomorphic.
+type Mealy = MealyM Identity
+
+instance (Applicative m) => Trifunctor.Semigroupal (->) (,) (,) (,) (,) (MealyM m) where
+  combine :: (MealyM m s i o, MealyM m t i' o') -> MealyM m (s, t) (i, i') (o, o')
+  combine (MealyM m1, MealyM m2) = MealyM $ \(s, t) (i, i') ->
+    liftA2 (curry (\((o, s'), (o', t')) -> ((o, o'), (s', t')))) (m1 s i) (m2 t i')
+
+instance (Functor m) => Trifunctor.Semigroupal (->) (,) Either Either (,) (MealyM m) where
+  combine :: (MealyM m s i o, MealyM m t i' o') -> MealyM m (s, t) (Either i i') (Either o o')
+  combine (MealyM m1, MealyM m2) = MealyM $ \(s, t) -> \case
+    Left i -> (bimap Left (,t) <$> m1 s i)
+    Right i' -> bimap Right (s,) <$> m2 t i'
+
+instance (Applicative m) => Trifunctor.Semigroupal (->) (,) These These (,) (MealyM m) where
+  combine :: (MealyM m s i o, MealyM m t i' o') -> MealyM m (s, t) (These i i') (These o o')
+  combine (MealyM m1, MealyM m2) = MealyM $ \(s, t) -> \case
+    This i -> bimap This (,t) <$> m1 s i
+    That i' -> bimap That (s,) <$> m2 t i'
+    These i i' -> do
+      liftA2 (curry (\((o, s'), (o', t')) -> (These o o', (s', t')))) (m1 s i) (m2 t i')
+
+instance (Applicative m) => Trifunctor.Unital (->) () () () () (MealyM m) where
+  introduce :: () -> MealyM m () () ()
+  introduce () = MealyM $ \() () -> pure ((), ())
+
+instance Trifunctor.Unital (->) () Void Void () (MealyM m) where
+  introduce :: () -> MealyM m () Void Void
+  introduce () = MealyM $ \() -> absurd
+
+instance (Applicative m) => Trifunctor.Monoidal (->) (,) () (,) () (,) () (,) () (MealyM m)
+
+instance (Applicative m) => Trifunctor.Monoidal (->) (,) () Either Void Either Void (,) () (MealyM m)
+
+instance (Applicative m) => Trifunctor.Monoidal (->) (,) () These Void These Void (,) () (MealyM m)
+
+instance (Functor m) => Profunctor (MealyM m s) where
+  dimap :: (i' -> i) -> (o -> o') -> MealyM m s i o -> MealyM m s i' o'
+  dimap f g (MealyM mealy) = MealyM $ fmap (dimap f (fmap (first g))) mealy
+
+instance (Functor m) => Strong (MealyM m s) where
+  first' :: MealyM m s i o -> MealyM m s (i, c) (o, c)
+  first' (MealyM mealy) = MealyM $ \s (i, c) -> first (,c) <$> mealy s i
+
+instance (Monad m) => Category (MealyM m s) where
+  id :: (Monad m) => MealyM m s a a
+  id = MealyM $ \s i ->
+    pure (i, s)
+
+  (.) :: (Monad m) => MealyM m s b c -> MealyM m s a b -> MealyM m s a c
+  MealyM m2 . MealyM m1 = MealyM $ \s a ->
+    m1 s a >>= uncurry m2 . swap
+
+-- | Lift a monad morphism from @m@ to @n@ into a monad morphism from
+-- @MealyM m s i o@ to @MealyM n s i o@
+hoistMealyM :: (Functor n) => (forall x. m x -> n x) -> MealyM m s i o -> MealyM n s i o
+hoistMealyM f (MealyM b) = MealyM $ \s i -> f $ b s i
+
+--------------------------------------------------------------------------------
+
+-- | Take the fixpoint of @Mealy s i o@ by recursively constructing an
+-- @s -> Mealy' i o@ action adn tupling it with the output observation
+-- @o@ from its parent action.
+fixMealyM :: forall m s i o. (Functor m) => MealyM m s i o -> s -> MealyM' m i o
+fixMealyM (MealyM mealy) = go
+  where
+    go :: s -> MealyM' m i o
+    go s = MealyM' (fmap (second' go) . mealy s)
+
+-- | Monomorphised 'fixMealyM'.
+fixMealy :: forall s i o. Mealy s i o -> s -> Mealy' i o
+fixMealy = fixMealyM
+
+--------------------------------------------------------------------------------
+
+-- | Feed inputs into a 'Mealy' Machine and extract the observation at
+-- each state/input in a 'scan' style.
+scanMealyM :: (Monad m) => s -> [i] -> MealyM m s i o -> m [(o, s)]
+scanMealyM initialState inputs machine =
+  case inputs of
+    [] -> pure []
+    input : xs -> do
+      (o, s) <- runMealy machine initialState input
+      ys <- scanMealyM s xs machine
+      pure $ (o, s) : ys
+
+-- | Monomorphised 'scanMealyM'.
+scanMealy :: s -> [i] -> Mealy s i o -> [(o, s)]
+scanMealy initialState inputs machine = runIdentity $ scanMealyM initialState inputs machine
+
+-- | Feed inputs into a 'Mealy' Machine and then observe the final
+-- result.
+processMealyM :: (Monad m) => s -> [i] -> MealyM m s i o -> m o
+processMealyM state' inputs machine =
+  case inputs of
+    [] -> undefined
+    [input] -> fmap fst (runMealy machine state' input)
+    input : xs -> do
+      (_o, s) <- runMealy machine state' input
+      processMealyM s xs machine
+
+-- | Monomorphised 'processMealyM'.
+processMealy :: s -> [i] -> Mealy s i o -> o
+processMealy state' inputs machine = runIdentity $ processMealyM state' inputs machine

--- a/machines-coalgebras/src/Data/Machine/Mealy/Coalgebra/Monoidal.hs
+++ b/machines-coalgebras/src/Data/Machine/Mealy/Coalgebra/Monoidal.hs
@@ -11,7 +11,7 @@ where
 --------------------------------------------------------------------------------
 
 import Control.Category.Cartesian (split)
-import Data.Machine.Mealy.Coalgebra (MealyM (..))
+import Data.Machine.Mealy.Coalgebra (MealyTC (..))
 import Data.Profunctor (Profunctor (..), Strong (..))
 import Data.These (These)
 import Data.Trifunctor.Monoidal ((|*&&|), (|***|), (|*++|))
@@ -22,15 +22,15 @@ import Data.Trifunctor.Monoidal ((|*&&|), (|***|), (|*++|))
 -- the inputs to the input bots and produces a wedge product of their
 -- outputs.
 nudge ::
-  (Monad m) => Either (MealyM m s i o) (MealyM m s i' o') -> MealyM m s (Either i i') (Maybe (Either o o'))
+  (Monad m) => Either (MealyTC m s i o) (MealyTC m s i' o') -> MealyTC m s (Either i i') (Maybe (Either o o'))
 nudge =
   either
-    ( \(MealyM b) -> MealyM $ \s ->
+    ( \(MealyTC b) -> MealyTC $ \s ->
         either
           (fmap (fmap (first' (Just . Left))) $ b s)
           (const $ pure $ (,) Nothing s)
     )
-    ( \(MealyM b) -> MealyM $ \s ->
+    ( \(MealyTC b) -> MealyTC $ \s ->
         either
           (const $ pure $ (,) Nothing s)
           (fmap (fmap (first' (Just . Right))) $ b s)
@@ -38,25 +38,25 @@ nudge =
 
 -- | Nudge a bot into the left side of a bot with a summed input and
 -- wedge product output.
-nudgeLeft :: (Monad m) => MealyM m s i o -> MealyM m s (Either i i') (Maybe (Either o o'))
+nudgeLeft :: (Monad m) => MealyTC m s i o -> MealyTC m s (Either i i') (Maybe (Either o o'))
 nudgeLeft = nudge . Left
 
 -- | Nudge a bot into the right side of a bot with a summed input and
 -- wedge product output.
-nudgeRight :: (Monad m) => MealyM m s i' o' -> MealyM m s (Either i i') (Maybe (Either o o'))
+nudgeRight :: (Monad m) => MealyTC m s i' o' -> MealyTC m s (Either i i') (Maybe (Either o o'))
 nudgeRight = nudge . Right
 
 infixr 9 /\
 
-(/\) :: (Applicative m) => MealyM m s i o -> MealyM m t i o' -> MealyM m (s, t) i (o, o')
+(/\) :: (Applicative m) => MealyTC m s i o -> MealyTC m t i o' -> MealyTC m (s, t) i (o, o')
 (/\) m1 m2 = lmap split $ m1 |***| m2
 
 infixr 9 /+\
 
-(/+\) :: (Applicative m) => MealyM m s i o -> MealyM m t i' o' -> MealyM m (s, t) (These i i') (These o o')
+(/+\) :: (Applicative m) => MealyTC m s i o -> MealyTC m t i' o' -> MealyTC m (s, t) (These i i') (These o o')
 (/+\) m1 m2 = m1 |*&&| m2
 
 infixr 9 \/
 
-(\/) :: (Applicative m) => MealyM m s i o -> MealyM m t i' o' -> MealyM m (s, t) (Either i i') (Either o o')
+(\/) :: (Applicative m) => MealyTC m s i o -> MealyTC m t i' o' -> MealyTC m (s, t) (Either i i') (Either o o')
 (\/) m1 m2 = m1 |*++| m2

--- a/machines-coalgebras/src/Data/Machine/Mealy/Coalgebra/Monoidal.hs
+++ b/machines-coalgebras/src/Data/Machine/Mealy/Coalgebra/Monoidal.hs
@@ -1,0 +1,62 @@
+module Data.Machine.Mealy.Coalgebra.Monoidal
+  ( nudge,
+    nudgeLeft,
+    nudgeRight,
+    (/\),
+    (/+\),
+    (\/),
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Control.Category.Cartesian (split)
+import Data.Machine.Mealy.Coalgebra (MealyM (..))
+import Data.Profunctor (Profunctor (..), Strong (..))
+import Data.These (These)
+import Data.Trifunctor.Monoidal ((|*&&|), (|***|), (|*++|))
+
+--------------------------------------------------------------------------------
+
+-- | Given the sum of two bots, produce a bot who receives the sum of
+-- the inputs to the input bots and produces a wedge product of their
+-- outputs.
+nudge ::
+  (Monad m) => Either (MealyM m s i o) (MealyM m s i' o') -> MealyM m s (Either i i') (Maybe (Either o o'))
+nudge =
+  either
+    ( \(MealyM b) -> MealyM $ \s ->
+        either
+          (fmap (fmap (first' (Just . Left))) $ b s)
+          (const $ pure $ (,) Nothing s)
+    )
+    ( \(MealyM b) -> MealyM $ \s ->
+        either
+          (const $ pure $ (,) Nothing s)
+          (fmap (fmap (first' (Just . Right))) $ b s)
+    )
+
+-- | Nudge a bot into the left side of a bot with a summed input and
+-- wedge product output.
+nudgeLeft :: (Monad m) => MealyM m s i o -> MealyM m s (Either i i') (Maybe (Either o o'))
+nudgeLeft = nudge . Left
+
+-- | Nudge a bot into the right side of a bot with a summed input and
+-- wedge product output.
+nudgeRight :: (Monad m) => MealyM m s i' o' -> MealyM m s (Either i i') (Maybe (Either o o'))
+nudgeRight = nudge . Right
+
+infixr 9 /\
+
+(/\) :: (Applicative m) => MealyM m s i o -> MealyM m t i o' -> MealyM m (s, t) i (o, o')
+(/\) m1 m2 = lmap split $ m1 |***| m2
+
+infixr 9 /+\
+
+(/+\) :: (Applicative m) => MealyM m s i o -> MealyM m t i' o' -> MealyM m (s, t) (These i i') (These o o')
+(/+\) m1 m2 = m1 |*&&| m2
+
+infixr 9 \/
+
+(\/) :: (Applicative m) => MealyM m s i o -> MealyM m t i' o' -> MealyM m (s, t) (Either i i') (Either o o')
+(\/) m1 m2 = m1 |*++| m2

--- a/machines-coalgebras/src/Data/Machine/Moore.hs
+++ b/machines-coalgebras/src/Data/Machine/Moore.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE CPP #-}
+
+module Data.Machine.Moore where
+
+--------------------------------------------------------------------------------
+
+#if !MIN_VERSION_base(4,18,0)
+import Control.Applicative (liftA2)
+#endif
+import Control.Category.Cartesian (Semicartesian (..))
+import Control.Monad.Trans (MonadTrans (..))
+import Data.Bifunctor (Bifunctor (..))
+import Data.Bifunctor.Monoidal ((|**|))
+import Data.Bifunctor.Monoidal qualified as Bifunctor
+import Data.Functor.Identity (Identity (..))
+import Data.Profunctor (Closed (..), Costrong (..), Profunctor (..))
+import Data.Profunctor.Rep (Corepresentable (..))
+import Data.Profunctor.Sieve (Cosieve (..))
+import Data.Void (Void, absurd)
+
+--------------------------------------------------------------------------------
+
+-- | The fixed point of a 'MooreM' Machine. By taking the fixpoint we
+-- are able to hide the state parameter @s@.
+newtype MooreM' m i o = MooreM' {runMooreM' :: m (o, i -> MooreM' m i o)}
+  deriving (Functor)
+
+instance (Applicative m) => Applicative (MooreM' m i) where
+  pure :: o -> MooreM' m i o
+  pure o = let r = MooreM' $ pure (o, const r) in r
+
+#if !MIN_VERSION_base(4,18,0)
+  (<*>) :: MooreM' m i (a -> b) -> MooreM' m i a -> MooreM' m i b
+  (<*>) m1 m2 = dimap split (uncurry ($)) $ m1 |**| m2
+#else
+  liftA2 :: (o -> o' -> o'') -> MooreM' m i o -> MooreM' m i o' -> MooreM' m i o''
+  liftA2 f m1 m2 = dimap split (uncurry f) $ m1 |**| m2
+#endif
+
+instance (Applicative m) => Bifunctor.Semigroupal (->) (,) (,) (,) (MooreM' m) where
+  combine :: (MooreM' m i o, MooreM' m i' o') -> MooreM' m (i, i') (o, o')
+  combine (MooreM' m1, MooreM' m2) =
+    MooreM' $ liftA2 (\(o, m1') (o', m2') -> ((o, o'), \(i, i') -> Bifunctor.combine (m1' i, m2' i'))) m1 m2
+
+instance (Applicative m) => Bifunctor.Unital (->) () () () (MooreM' m) where
+  introduce :: () -> MooreM' m () ()
+  introduce () = MooreM' $ pure ((), Bifunctor.introduce)
+
+instance (Applicative m) => Bifunctor.Unital (->) Void () () (MooreM' m) where
+  introduce :: () -> MooreM' m Void ()
+  introduce () = MooreM' $ pure ((), absurd)
+
+instance (Applicative m) => Bifunctor.Monoidal (->) (,) () (,) () (,) () (MooreM' m)
+
+instance (Applicative m, Semigroup o) => Semigroup (MooreM' m i o) where
+  (<>) :: MooreM' m i o -> MooreM' m i o -> MooreM' m i o
+  MooreM' m1 <> MooreM' m2 = MooreM' $ liftA2 (<>) m1 m2
+
+instance (Applicative m, Monoid o) => Monoid (MooreM' m i o) where
+  mempty :: MooreM' m i o
+  mempty = MooreM' $ pure mempty
+
+instance (Functor m) => Profunctor (MooreM' m) where
+  dimap :: (i' -> i) -> (o -> o') -> MooreM' m i o -> MooreM' m i' o'
+  dimap f g (MooreM' moore) =
+    MooreM' $ fmap (bimap g (dimap f (dimap f g))) moore
+
+instance (Functor m) => Costrong (MooreM' m) where
+  unfirst :: MooreM' m (i, d) (o, d) -> MooreM' m i o
+  unfirst (MooreM' moore) = MooreM' $ fmap (\((o, d), m) -> (o, \i -> unfirst (m (i, d)))) moore
+
+--------------------------------------------------------------------------------
+
+-- | Lift a monad morphism from @m@ to @n@ into a monad morphism from
+-- @Env m s o i@ to @Env n s o i@
+hoistMooreM' :: (Functor n) => (forall x. m x -> n x) -> MooreM' m o i -> MooreM' n o i
+hoistMooreM' f (MooreM' server) = MooreM' $ fmap (fmap (fmap (hoistMooreM' f))) $ f server
+
+-- | Lift a computation on the monad @m@ to the constructed monad @t
+-- m@ in the context of a 'Server'.
+liftMooreM' :: (Functor (t m), Monad m, MonadTrans t) => MooreM' m o i -> MooreM' (t m) o i
+liftMooreM' = hoistMooreM' lift
+
+--------------------------------------------------------------------------------
+
+-- | The fixed point of a 'Moore' Machine. By taking the fixpoint we
+-- are able to hide the state parameter @s@.
+type Moore' = MooreM' Identity
+
+instance Cosieve Moore' [] where
+  cosieve :: Moore' i o -> [i] -> o
+  cosieve (runIdentity . runMooreM' -> (o, _)) [] = o
+  cosieve (runIdentity . runMooreM' -> (_, k)) (x : xs) = cosieve (k x) xs
+
+instance Corepresentable Moore' where
+  type Corep Moore' = []
+
+  cotabulate :: (Corep Moore' i -> o) -> Moore' i o
+  cotabulate f = MooreM' $ Identity (f [], \i -> cotabulate (f . (i :)))
+
+instance Closed Moore' where
+  closed :: Moore' i o -> Moore' (x -> i) (x -> o)
+  closed m = cotabulate $ \fs x -> cosieve m (fmap ($ x) fs)
+
+--------------------------------------------------------------------------------
+
+-- | Feed inputs into a 'MooreM'' Machine and then observe the final
+-- result.
+processMooreM' :: (Monad m) => [i] -> MooreM' m i o -> m o
+processMooreM' [] (MooreM' moore) = fmap fst moore
+processMooreM' (i : xs) (MooreM' moore) = do
+  (_, nextMoore) <- moore
+  processMooreM' xs (nextMoore i)
+
+-- | Feed inputs into a 'Moore'' Machine and then observe the final
+-- result.
+processMoore' :: [i] -> Moore' i o -> o
+processMoore' = flip cosieve

--- a/machines-coalgebras/src/Data/Machine/Moore.hs
+++ b/machines-coalgebras/src/Data/Machine/Moore.hs
@@ -1,118 +1,81 @@
 {-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
-module Data.Machine.Moore where
+-- | The fixed point of a 'MooreT Machine. By taking the fixpoint we
+-- are able to hide the state parameter @s@.
+module Data.Machine.Moore
+  ( MooreT (..),
+    Moore,
+    hoistMooreT,
+    liftMooreT,
+    processMooreT,
+    processMoore,
+  )
+where
 
 --------------------------------------------------------------------------------
 
 #if !MIN_VERSION_base(4,18,0)
 import Control.Applicative (liftA2)
 #endif
-import Control.Category.Cartesian (Semicartesian (..))
 import Control.Monad.Trans (MonadTrans (..))
-import Data.Bifunctor (Bifunctor (..))
-import Data.Bifunctor.Monoidal ((|**|))
 import Data.Bifunctor.Monoidal qualified as Bifunctor
 import Data.Functor.Identity (Identity (..))
-import Data.Profunctor (Closed (..), Costrong (..), Profunctor (..))
-import Data.Profunctor.Rep (Corepresentable (..))
+import Data.Machine.MooreT (MooreT (..))
 import Data.Profunctor.Sieve (Cosieve (..))
 import Data.Void (Void, absurd)
 
 --------------------------------------------------------------------------------
 
--- | The fixed point of a 'MooreM' Machine. By taking the fixpoint we
--- are able to hide the state parameter @s@.
-newtype MooreM' m i o = MooreM' {runMooreM' :: m (o, i -> MooreM' m i o)}
-  deriving (Functor)
+instance (Applicative m) => Bifunctor.Semigroupal (->) (,) (,) (,) (MooreT m) where
+  combine :: (MooreT m i o, MooreT m i' o') -> MooreT m (i, i') (o, o')
+  combine (MooreT m1, MooreT m2) =
+    MooreT $ liftA2 (\(o, m1') (o', m2') -> ((o, o'), \(i, i') -> Bifunctor.combine (m1' i, m2' i'))) m1 m2
 
-instance (Applicative m) => Applicative (MooreM' m i) where
-  pure :: o -> MooreM' m i o
-  pure o = let r = MooreM' $ pure (o, const r) in r
+instance (Applicative m) => Bifunctor.Unital (->) () () () (MooreT m) where
+  introduce :: () -> MooreT m () ()
+  introduce () = MooreT $ pure ((), Bifunctor.introduce)
 
-#if !MIN_VERSION_base(4,18,0)
-  (<*>) :: MooreM' m i (a -> b) -> MooreM' m i a -> MooreM' m i b
-  (<*>) m1 m2 = dimap split (uncurry ($)) $ m1 |**| m2
-#else
-  liftA2 :: (o -> o' -> o'') -> MooreM' m i o -> MooreM' m i o' -> MooreM' m i o''
-  liftA2 f m1 m2 = dimap split (uncurry f) $ m1 |**| m2
-#endif
+instance (Applicative m) => Bifunctor.Unital (->) Void () () (MooreT m) where
+  introduce :: () -> MooreT m Void ()
+  introduce () = MooreT $ pure ((), absurd)
 
-instance (Applicative m) => Bifunctor.Semigroupal (->) (,) (,) (,) (MooreM' m) where
-  combine :: (MooreM' m i o, MooreM' m i' o') -> MooreM' m (i, i') (o, o')
-  combine (MooreM' m1, MooreM' m2) =
-    MooreM' $ liftA2 (\(o, m1') (o', m2') -> ((o, o'), \(i, i') -> Bifunctor.combine (m1' i, m2' i'))) m1 m2
-
-instance (Applicative m) => Bifunctor.Unital (->) () () () (MooreM' m) where
-  introduce :: () -> MooreM' m () ()
-  introduce () = MooreM' $ pure ((), Bifunctor.introduce)
-
-instance (Applicative m) => Bifunctor.Unital (->) Void () () (MooreM' m) where
-  introduce :: () -> MooreM' m Void ()
-  introduce () = MooreM' $ pure ((), absurd)
-
-instance (Applicative m) => Bifunctor.Monoidal (->) (,) () (,) () (,) () (MooreM' m)
-
-instance (Applicative m, Semigroup o) => Semigroup (MooreM' m i o) where
-  (<>) :: MooreM' m i o -> MooreM' m i o -> MooreM' m i o
-  MooreM' m1 <> MooreM' m2 = MooreM' $ liftA2 (<>) m1 m2
-
-instance (Applicative m, Monoid o) => Monoid (MooreM' m i o) where
-  mempty :: MooreM' m i o
-  mempty = MooreM' $ pure mempty
-
-instance (Functor m) => Profunctor (MooreM' m) where
-  dimap :: (i' -> i) -> (o -> o') -> MooreM' m i o -> MooreM' m i' o'
-  dimap f g (MooreM' moore) =
-    MooreM' $ fmap (bimap g (dimap f (dimap f g))) moore
-
-instance (Functor m) => Costrong (MooreM' m) where
-  unfirst :: MooreM' m (i, d) (o, d) -> MooreM' m i o
-  unfirst (MooreM' moore) = MooreM' $ fmap (\((o, d), m) -> (o, \i -> unfirst (m (i, d)))) moore
+instance (Applicative m) => Bifunctor.Monoidal (->) (,) () (,) () (,) () (MooreT m)
 
 --------------------------------------------------------------------------------
 
 -- | Lift a monad morphism from @m@ to @n@ into a monad morphism from
 -- @Env m s o i@ to @Env n s o i@
-hoistMooreM' :: (Functor n) => (forall x. m x -> n x) -> MooreM' m o i -> MooreM' n o i
-hoistMooreM' f (MooreM' server) = MooreM' $ fmap (fmap (fmap (hoistMooreM' f))) $ f server
+hoistMooreT :: (Functor n) => (forall x. m x -> n x) -> MooreT m o i -> MooreT n o i
+hoistMooreT f (MooreT server) = MooreT $ fmap (fmap (fmap (hoistMooreT f))) $ f server
 
 -- | Lift a computation on the monad @m@ to the constructed monad @t
 -- m@ in the context of a 'Server'.
-liftMooreM' :: (Functor (t m), Monad m, MonadTrans t) => MooreM' m o i -> MooreM' (t m) o i
-liftMooreM' = hoistMooreM' lift
+liftMooreT :: (Functor (t m), Monad m, MonadTrans t) => MooreT m o i -> MooreT (t m) o i
+liftMooreT = hoistMooreT lift
 
 --------------------------------------------------------------------------------
 
 -- | The fixed point of a 'Moore' Machine. By taking the fixpoint we
 -- are able to hide the state parameter @s@.
-type Moore' = MooreM' Identity
+type Moore = MooreT Identity
 
-instance Cosieve Moore' [] where
-  cosieve :: Moore' i o -> [i] -> o
-  cosieve (runIdentity . runMooreM' -> (o, _)) [] = o
-  cosieve (runIdentity . runMooreM' -> (_, k)) (x : xs) = cosieve (k x) xs
-
-instance Corepresentable Moore' where
-  type Corep Moore' = []
-
-  cotabulate :: (Corep Moore' i -> o) -> Moore' i o
-  cotabulate f = MooreM' $ Identity (f [], \i -> cotabulate (f . (i :)))
-
-instance Closed Moore' where
-  closed :: Moore' i o -> Moore' (x -> i) (x -> o)
-  closed m = cotabulate $ \fs x -> cosieve m (fmap ($ x) fs)
+instance Cosieve Moore [] where
+  cosieve :: Moore i o -> [i] -> o
+  cosieve (runIdentity . runMooreT -> (o, _)) [] = o
+  cosieve (runIdentity . runMooreT -> (_, k)) (x : xs) = cosieve (k x) xs
 
 --------------------------------------------------------------------------------
 
--- | Feed inputs into a 'MooreM'' Machine and then observe the final
+-- | Feed inputs into a 'MooreT' Machine and then observe the final
 -- result.
-processMooreM' :: (Monad m) => [i] -> MooreM' m i o -> m o
-processMooreM' [] (MooreM' moore) = fmap fst moore
-processMooreM' (i : xs) (MooreM' moore) = do
+processMooreT :: (Monad m) => [i] -> MooreT m i o -> m o
+processMooreT [] (MooreT moore) = fmap fst moore
+processMooreT (i : xs) (MooreT moore) = do
   (_, nextMoore) <- moore
-  processMooreM' xs (nextMoore i)
+  processMooreT xs (nextMoore i)
 
 -- | Feed inputs into a 'Moore'' Machine and then observe the final
 -- result.
-processMoore' :: [i] -> Moore' i o -> o
-processMoore' = flip cosieve
+processMoore :: [i] -> Moore i o -> o
+processMoore = flip cosieve

--- a/machines-coalgebras/src/Data/Machine/Moore/Coalgebra.hs
+++ b/machines-coalgebras/src/Data/Machine/Moore/Coalgebra.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE CPP #-}
+
+-- | Moore Machines and related machinery.
+module Data.Machine.Moore.Coalgebra
+  ( MooreM (..),
+    Moore,
+    MooreM' (..),
+    Moore',
+    fixMooreM,
+    fixMoore,
+    scanMooreM,
+    scanMoore,
+    processMooreM,
+    processMoore,
+    processMooreM',
+    processMoore',
+  )
+where
+
+--------------------------------------------------------------------------------
+
+#if !MIN_VERSION_base(4,18,0)
+import Control.Applicative (liftA2)
+#endif
+import Control.Arrow
+import Control.Monad.Identity (Identity (..))
+import Data.Biapplicative
+import Data.Bifunctor.Monoidal qualified as Bifunctor
+import Data.Bifunctor.Monoidal.Specialized (biapply)
+import Data.Machine.Moore
+import Data.Profunctor (Profunctor (..))
+import Data.These (These (..), these)
+import Data.Trifunctor.Monoidal qualified as Trifunctor
+import Data.Void (Void)
+
+--------------------------------------------------------------------------------
+
+-- | Monadic Moore Machine consists of:
+--
+--   * A finite set of states @S@
+--   * An initial state @s : S@
+--   * A monad @M@
+--   * A finite set called the input @I@
+--   * A finite set called the output @O@
+--   * A function @transistion : S × I → S@
+--   * A function @observe : S → O@
+--
+-- In this particular encoding we receive the initial state and
+-- produce a tuple of the observation at the initial state and the
+-- next state transition function.
+newtype MooreM m s i o = MooreM {runMooreM :: s -> m (o, i -> s)}
+  deriving (Functor)
+
+instance (Applicative m) => Trifunctor.Semigroupal (->) (,) (,) (,) (,) (MooreM m) where
+  combine :: (MooreM m s i o, MooreM m t i' o') -> MooreM m (s, t) (i, i') (o, o')
+  combine (MooreM m1, MooreM m2) =
+    MooreM $ \(s, t) ->
+      liftA2 (curry $ fmap biapply . Bifunctor.combine @(->) @(,) @(,)) (m1 s) (m2 t)
+
+instance (Applicative m) => Trifunctor.Semigroupal (->) (,) Either (,) (,) (MooreM m) where
+  combine :: (MooreM m s i o, MooreM m t i' o') -> MooreM m (s, t) (Either i i') (o, o')
+  combine (MooreM m1, MooreM m2) =
+    MooreM $ \(s, t) -> liftA2 (curry $ fmap (\(f, g) -> either ((,t) . f) ((s,) . g)) . Bifunctor.combine @(->) @(,) @(,)) (m1 s) (m2 t)
+
+instance (Applicative m) => Trifunctor.Semigroupal (->) (,) These (,) (,) (MooreM m) where
+  combine :: (MooreM m s i o, MooreM m t i' o') -> MooreM m (s, t) (These i i') (o, o')
+  combine (MooreM m1, MooreM m2) =
+    MooreM $ \(s, t) -> liftA2 (curry $ fmap (\(f, g) -> these ((,t) . f) ((s,) . g) (curry (f *** g))) . Bifunctor.combine @(->) @(,) @(,)) (m1 s) (m2 t)
+
+instance (Applicative m) => Trifunctor.Unital (->) () () () () (MooreM m) where
+  introduce :: () -> MooreM m () () ()
+  introduce () = MooreM $ \() -> pure ((), const ())
+
+instance (Applicative m) => Trifunctor.Unital (->) () Void () () (MooreM m) where
+  introduce :: () -> MooreM m () Void ()
+  introduce () = MooreM $ \() -> pure ((), const ())
+
+instance (Applicative m) => Trifunctor.Monoidal (->) (,) () (,) () (,) () (,) () (MooreM m)
+
+instance (Applicative m) => Trifunctor.Monoidal (->) (,) () Either Void (,) () (,) () (MooreM m)
+
+instance (Applicative m) => Trifunctor.Monoidal (->) (,) () These Void (,) () (,) () (MooreM m)
+
+instance (Functor m) => Profunctor (MooreM m s) where
+  dimap :: (i' -> i) -> (o -> o') -> MooreM m s i o -> MooreM m s i' o'
+  dimap f g (MooreM moore) = MooreM $ fmap (fmap (bimap g (lmap f))) moore
+
+-- | Moore Machine
+--
+--   * A finite set of states @S@
+--   * An initial state @s : S@
+--   * A finite set called the input @I@
+--   * A finite set called the output @O@
+--   * A function @transistion : S × I → S@
+--   * A function @observe : S → O@
+--
+-- In this particular encoding we receive the initial state and
+-- produce a tuple of the observation at the initial state and the
+-- next state transition function.
+type Moore = MooreM Identity
+
+--------------------------------------------------------------------------------
+
+-- | Take the fixpoint of @MooreM s i o@ by recursively constructing an
+-- @s -> MooreM' i o@ action and tupling it with the output observation
+-- @o@ from its parent action.
+fixMooreM :: forall m s o i. (Functor m) => MooreM m s o i -> s -> MooreM' m o i
+fixMooreM (MooreM moore) = go
+  where
+    go :: s -> MooreM' m o i
+    go s = MooreM' $ fmap (fmap go) <$> moore s
+
+-- | Take the fixpoint of @Moore s i o@ by recursively constructing an
+-- @s -> Moore' i o@ action and tupling it with the output observation
+-- @o@ from its parent action.
+fixMoore :: forall s o i. Moore s o i -> s -> Moore' o i
+fixMoore = fixMooreM
+
+--------------------------------------------------------------------------------
+
+-- | Feed inputs into a 'Moore' Machine and extract the observation at
+-- each state/input in a 'scan' style.
+scanMooreM :: (Monad m) => s -> [i] -> MooreM m s i o -> m [(o, s)]
+scanMooreM state' inputs machine = do
+  (o, transition) <- runMooreM machine state'
+  case inputs of
+    [] -> pure [(o, state')]
+    i : xs -> do
+      ys <- scanMooreM (transition i) xs machine
+      pure $ (o, state') : ys
+
+-- | Feed inputs into a 'Moore' Machine and extract the observation at
+-- each state/input in a 'scan' style.
+scanMoore :: s -> [i] -> Moore s i o -> [(o, s)]
+scanMoore state' inputs machine =
+  let (o, transition) = runIdentity $ runMooreM machine state'
+   in case inputs of
+        [] -> [(o, state')]
+        i : xs -> (o, state') : scanMoore (transition i) xs machine
+
+-- | Feed inputs into a 'Moore' Machine and then observe the final
+-- result.
+processMooreM :: (Monad m) => s -> [i] -> MooreM m s i o -> m o
+processMooreM initialState inputs machine = do
+  (o, transition) <- runMooreM machine initialState
+  case inputs of
+    [] -> pure o
+    i : xs -> processMooreM (transition i) xs machine
+
+-- | Feed inputs into a 'Moore' Machine and then observe the final
+-- result.
+processMoore :: s -> [i] -> Moore s i o -> o
+processMoore initialState inputs machine =
+  let (o, transition) = runIdentity $ runMooreM machine initialState
+   in case inputs of
+        [] -> o
+        i : xs -> processMoore (transition i) xs machine

--- a/machines-coalgebras/src/Data/Machine/Moore/Coalgebra/Monoidal.hs
+++ b/machines-coalgebras/src/Data/Machine/Moore/Coalgebra/Monoidal.hs
@@ -8,7 +8,7 @@ where
 --------------------------------------------------------------------------------
 
 import Control.Category.Cartesian (Semicartesian (..))
-import Data.Machine.Moore.Coalgebra (MooreM)
+import Data.Machine.Moore.Coalgebra (MooreTC)
 import Data.Profunctor (Profunctor (..))
 import Data.These (These)
 import Data.Trifunctor.Monoidal ((|*&*|), (|***|), (|*+*|))
@@ -18,15 +18,15 @@ import Data.Trifunctor.Monoidal ((|*&*|), (|***|), (|*+*|))
 
 infixr 9 /\
 
-(/\) :: (Applicative m) => MooreM m s i o -> MooreM m t i o' -> MooreM m (s, t) i (o, o')
+(/\) :: (Applicative m) => MooreTC m s i o -> MooreTC m t i o' -> MooreTC m (s, t) i (o, o')
 (/\) m1 m2 = lmap split $ m1 |***| m2
 
 infixr 9 /+\
 
-(/+\) :: (Applicative m) => MooreM m s i o -> MooreM m t i' o' -> MooreM m (s, t) (These i i') (o, o')
+(/+\) :: (Applicative m) => MooreTC m s i o -> MooreTC m t i' o' -> MooreTC m (s, t) (These i i') (o, o')
 (/+\) m1 m2 = m1 |*&*| m2
 
 infixr 9 \/
 
-(\/) :: (Applicative m) => MooreM m s i o -> MooreM m t i' o' -> MooreM m (s, t) (Either i i') (o, o')
+(\/) :: (Applicative m) => MooreTC m s i o -> MooreTC m t i' o' -> MooreTC m (s, t) (Either i i') (o, o')
 (\/) m1 m2 = m1 |*+*| m2

--- a/machines-coalgebras/src/Data/Machine/Moore/Coalgebra/Monoidal.hs
+++ b/machines-coalgebras/src/Data/Machine/Moore/Coalgebra/Monoidal.hs
@@ -1,0 +1,32 @@
+module Data.Machine.Moore.Coalgebra.Monoidal
+  ( (/\),
+    (\/),
+    (/+\),
+  )
+where
+
+--------------------------------------------------------------------------------
+
+import Control.Category.Cartesian (Semicartesian (..))
+import Data.Machine.Moore.Coalgebra (MooreM)
+import Data.Profunctor (Profunctor (..))
+import Data.These (These)
+import Data.Trifunctor.Monoidal ((|*&*|), (|***|), (|*+*|))
+
+--------------------------------------------------------------------------------
+-- Tensors
+
+infixr 9 /\
+
+(/\) :: (Applicative m) => MooreM m s i o -> MooreM m t i o' -> MooreM m (s, t) i (o, o')
+(/\) m1 m2 = lmap split $ m1 |***| m2
+
+infixr 9 /+\
+
+(/+\) :: (Applicative m) => MooreM m s i o -> MooreM m t i' o' -> MooreM m (s, t) (These i i') (o, o')
+(/+\) m1 m2 = m1 |*&*| m2
+
+infixr 9 \/
+
+(\/) :: (Applicative m) => MooreM m s i o -> MooreM m t i' o' -> MooreM m (s, t) (Either i i') (o, o')
+(\/) m1 m2 = m1 |*+*| m2


### PR DESCRIPTION
Factors out machines code into a standalone package `machines-coalgebra` which only implements the co-algebraic instances and fix point functions for mapping them into `Moore` and `Mealy` from `machines`. We then use `DerivingVia` to construct our chat bot types.